### PR TITLE
INT-1517: Default ssl for .mongodb.net deployments to unvalidated instead of none

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 var parallel = require('run-parallel');
 var series = require('run-series');
-var clone = require('lodash.clone');
+var _ = require('lodash');
 var MongoClient = require('mongodb').MongoClient;
 var backoff = require('backoff');
 var Connection = require('./model');
@@ -17,7 +17,7 @@ function loadOptions(model, done) {
   }
 
   var tasks = {};
-  var opts = clone(model.driver_options, true);
+  var opts = _.clone(model.driver_options, true);
   Object.keys(opts.server).map(function(key) {
     if (key.indexOf('ssl') === -1) {
       return;

--- a/lib/model.js
+++ b/lib/model.js
@@ -521,6 +521,7 @@ _.assign(derived, {
       'driver_auth_mechanism'
     ],
     fn: function() {
+      var ssl = this.ssl;
       var req = {
         protocol: 'mongodb',
         slashes: true,
@@ -572,7 +573,14 @@ _.assign(derived, {
         });
       }
 
-      if (_.includes(['UNVALIDATED', 'SERVER', 'ALL'], this.ssl)) {
+      /**
+       * @see http://jira.mongodb.org/browse/INT-1517
+       */
+      if (_.endsWith(req.hostname, '.mongodb.net') && ssl === 'NONE') {
+        ssl = 'UNVALIDATED';
+      }
+
+      if (_.includes(['UNVALIDATED', 'SERVER', 'ALL'], ssl)) {
         req.query.ssl = 'true';
       }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -2,10 +2,7 @@ var toURL = require('url').format;
 var format = require('util').format;
 var AmpersandModel = require('ampersand-model');
 var AmpersandCollection = require('ampersand-rest-collection');
-var assign = require('lodash.assign');
-var defaults = require('lodash.defaults');
-var contains = require('lodash.contains');
-var clone = require('lodash.clone');
+var _ = require('lodash');
 var parse = require('mongodb-url');
 var fs = require('fs');
 
@@ -18,7 +15,7 @@ var derived = {};
 /**
  * # Top-Level
  */
-assign(props, {
+_.assign(props, {
   /**
    * User specified name for this connection.
    *
@@ -45,7 +42,7 @@ assign(props, {
   }
 });
 
-assign(derived, {
+_.assign(derived, {
   /**
    * @see http://npm.im/mongodb-instance-model
    */
@@ -92,7 +89,7 @@ var AUTHENTICATION_VALUES = [
  */
 var AUTHENTICATION_DEFAULT = 'NONE';
 
-assign(props, {
+_.assign(props, {
   /**
    * @property {String} authentication - `auth_mechanism` for humans.
    */
@@ -114,7 +111,7 @@ var AUTHENICATION_TO_AUTH_MECHANISM = {
   LDAP: 'PLAIN'
 };
 
-assign(derived, {
+_.assign(derived, {
   /**
    * Converts the value of `authentication` (for humans)
    * into the `auth_mechanism` value for the driver.
@@ -182,7 +179,7 @@ var AUTHENTICATION_TO_FIELD_NAMES = {
  *     db: { readPreference: 'nearest' },
  *     replSet: { connectWithNoPrimary: true } }
  */
-assign(props, {
+_.assign(props, {
   mongodb_username: {
     type: 'string',
     default: undefined
@@ -226,7 +223,7 @@ var MONGODB_DATABASE_NAME_DEFAULT = 'admin';
  * @enterprise
  * @see http://bit.ly/mongodb-node-driver-kerberos
  */
-assign(props, {
+_.assign(props, {
   /**
    * Any program or computer you access over a network. Examples of
    * services include “host” (a host, e.g., when you use telnet and rsh),
@@ -288,7 +285,7 @@ var KERBEROS_SERVICE_NAME_DEFAULT = 'mongodb';
  * @enterprise
  * @see http://bit.ly/mongodb-node-driver-ldap
  */
-assign(props, {
+_.assign(props, {
   /**
    * @see http://bit.ly/mongodb-node-driver-ldap
    * @see http://bit.ly/mongodb-ldap
@@ -329,7 +326,7 @@ assign(props, {
  * @see http://bit.ly/mongodb-node-driver-x509
  * @see http://bit.ly/mongodb-x509
  */
-assign(props, {
+_.assign(props, {
   /**
    * The x.509 certificate derived user name, e.g. "CN=user,OU=OrgUnit,O=myOrg,..."
    */
@@ -371,7 +368,7 @@ var SSL_VALUES = [
  */
 var SSL_DEFAULT = 'NONE';
 
-assign(props, {
+_.assign(props, {
   ssl: {
     type: 'string',
     values: SSL_VALUES,
@@ -435,7 +432,7 @@ var SSH_TUNNEL_VALUES = [
  */
 var SSH_TUNNEL_DEFAULT = 'NONE';
 
-assign(props, {
+_.assign(props, {
   ssh_tunnel: {
     type: 'string',
     values: SSH_TUNNEL_VALUES,
@@ -504,7 +501,7 @@ var DRIVER_OPTIONS_DEFAULT = {
   }
 };
 
-assign(derived, {
+_.assign(derived, {
   /**
    * Get the URL which can be passed to `MongoClient.connect`.
    * @see http://bit.ly/mongoclient-connect
@@ -548,7 +545,7 @@ assign(derived, {
         req.auth = format('%s:%s', this.mongodb_username, this.mongodb_password);
         req.query.authSource = this.mongodb_database_name;
       } else if (this.authentication === 'KERBEROS') {
-        defaults(req.query, {
+        _.defaults(req.query, {
           gssapiServiceName: this.kerberos_service_name,
           authMechanism: this.driver_auth_mechanism
         });
@@ -563,19 +560,19 @@ assign(derived, {
         }
       } else if (this.authentication === 'X509') {
         req.auth = encodeURIComponent(this.x509_username);
-        defaults(req.query, {
+        _.defaults(req.query, {
           authMechanism: this.driver_auth_mechanism
         });
       } else if (this.authentication === 'LDAP') {
         req.auth = format('%s:%s',
           encodeURIComponent(this.ldap_username),
           this.ldap_password);
-        defaults(req.query, {
+        _.defaults(req.query, {
           authMechanism: this.driver_auth_mechanism
         });
       }
 
-      if (contains(['UNVALIDATED', 'SERVER', 'ALL'], this.ssl)) {
+      if (_.includes(['UNVALIDATED', 'SERVER', 'ALL'], this.ssl)) {
         req.query.ssl = 'true';
       }
 
@@ -597,16 +594,16 @@ assign(derived, {
       'ssl_private_key_password'
     ],
     fn: function() {
-      var opts = clone(DRIVER_OPTIONS_DEFAULT, true);
+      var opts = _.clone(DRIVER_OPTIONS_DEFAULT, true);
       if (this.ssl === 'SERVER') {
-        assign(opts, {
+        _.assign(opts, {
           server: {
             sslValidate: true,
             sslCA: this.ssl_ca
           }
         });
       } else if (this.ssl === 'ALL') {
-        assign(opts, {
+        _.assign(opts, {
           server: {
             sslValidate: true,
             sslCA: this.ssl_ca,
@@ -644,13 +641,14 @@ assign(derived, {
         sshPort: this.ssh_tunnel_port
       };
       if (this.ssh_tunnel === 'USER_PASSWORD') {
-        assign(opts, { password: this.ssh_tunnel_password });
+        _.assign(opts, { password: this.ssh_tunnel_password });
       } else if (this.ssh_tunnel === 'IDENTITY_FILE') {
-        assign(opts, {
+        /* eslint no-sync: 0 */
+        _.assign(opts, {
           privateKey: fs.readFileSync(this.ssh_tunnel_identity_file[0])
         });
         if (this.ssh_tunnel_passphrase) {
-          assign(opts, { password: this.ssh_tunnel_passphrase });
+          _.assign(opts, { password: this.ssh_tunnel_passphrase });
         }
       }
       return opts;
@@ -731,7 +729,7 @@ Connection = AmpersandModel.extend({
    * @param {Object} attrs - Incoming attributes.
    */
   validate_ssl: function(attrs) {
-    if (!attrs.ssl || contains(['NONE', 'UNVALIDATED'], attrs.ssl)) {
+    if (!attrs.ssl || _.includes(['NONE', 'UNVALIDATED'], attrs.ssl)) {
       return;
     }
     if (attrs.ssl === 'SERVER' && !attrs.ssl_ca) {

--- a/package.json
+++ b/package.json
@@ -27,10 +27,7 @@
     "ampersand-model": "^8.0.0",
     "ampersand-rest-collection": "^5.0.0",
     "debug": "^2.2.0",
-    "lodash.assign": "^4.0.2",
-    "lodash.clone": "^3.0.3",
-    "lodash.contains": "^2.4.3",
-    "lodash.defaults": "^3.1.2",
+    "lodash": "^4.13.1",
     "mongodb-url": "^1.0.2"
   },
   "devDependencies": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -535,6 +535,15 @@ describe('mongodb-connection-model', function() {
         });
       });
     });
+    describe('When hostname ends with `mongodb.net`', function() {
+      /**
+       * @see http://jira.mongodb.org/browse/INT-1517
+       */
+      it('should default driver ssl to unvalidated', function() {
+        var c = Connection.from('mongodb://data.mongodb.net/');
+        assert.equal(c.driver_url, 'mongodb://data.mongodb.net:27017/?slaveOk=true&ssl=true');
+      });
+    });
   });
 
   describe('ssh tunnel', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,7 +4,7 @@ var loadOptions = Connection.connect.loadOptions;
 var parse = require('mongodb-url');
 var driverParse = require('mongodb/lib/url_parser');
 var fixture = require('mongodb-connection-fixture');
-var clone = require('lodash.clone');
+var _ = require('lodash');
 var format = require('util').format;
 var fs = require('fs');
 var path = require('path');
@@ -460,7 +460,7 @@ describe('mongodb-connection-model', function() {
           'mongodb://localhost:27017/?slaveOk=true&ssl=true');
       });
       it('should produce the correct driver options', function() {
-        var expected = clone(Connection.DRIVER_OPTIONS_DEFAULT);
+        var expected = _.clone(Connection.DRIVER_OPTIONS_DEFAULT);
         expected.server = {
           sslCA: [fixture.ssl.ca],
           sslValidate: true
@@ -494,7 +494,7 @@ describe('mongodb-connection-model', function() {
         });
 
         it('should produce the correct driver_options', function() {
-          var expected = clone(Connection.DRIVER_OPTIONS_DEFAULT);
+          var expected = _.clone(Connection.DRIVER_OPTIONS_DEFAULT);
           expected.server = {
             sslCA: [fixture.ssl.ca],
             sslCert: fixture.ssl.server,
@@ -523,7 +523,7 @@ describe('mongodb-connection-model', function() {
         });
 
         it('should produce the correct driver_options', function() {
-          var expected = clone(Connection.DRIVER_OPTIONS_DEFAULT);
+          var expected = _.clone(Connection.DRIVER_OPTIONS_DEFAULT);
           expected.server = {
             sslCA: [fixture.ssl.ca],
             sslCert: fixture.ssl.server,
@@ -623,6 +623,7 @@ describe('mongodb-connection-model', function() {
           });
 
           it('maps ssh_tunnel_identity_file -> privateKey', function() {
+            /* eslint no-sync: 0 */
             assert.equal(options.privateKey.toString(), fs.readFileSync(fileName).toString());
           });
 


### PR DESCRIPTION
Instead of leaving it to the users to know about this workaround, do it
for them automatically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/connection-model/78)
<!-- Reviewable:end -->
