### PR TITLE
INT-1709: SSL "If Available"

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -618,6 +618,13 @@ _.assign(derived, {
         if (this.ssl_private_key_password) {
           opts.server.sslPass = this.ssl_private_key_password;
         }
+      } else if (this.ssl === 'UNVALIDATED') {
+        _.assign(opts, {
+          server: {
+            checkServerIdentity: false,
+            sslValidate: false
+          }
+        });
       }
       opts.db.promoteValues = this.promote_values;
       return opts;

--- a/lib/model.js
+++ b/lib/model.js
@@ -356,6 +356,10 @@ var SSL_VALUES = [
    */
   'NONE',
   /**
+   * Use SSL if available.
+   */
+  'IFAVAILABLE',
+  /**
    * Use SSL but do not perform any validation of the certificate chain.
    */
   'UNVALIDATED',
@@ -372,7 +376,7 @@ var SSL_VALUES = [
 /**
  * @constant {String} - The default value for `ssl`.
  */
-var SSL_DEFAULT = 'NONE';
+var SSL_DEFAULT = 'IFAVAILABLE';
 
 _.assign(props, {
   ssl: {
@@ -574,7 +578,7 @@ _.assign(derived, {
         });
       }
 
-      if (_.includes(['UNVALIDATED', 'SERVER', 'ALL'], this.ssl)) {
+      if (_.includes(['UNVALIDATED', 'IFAVAILABLE', 'SERVER', 'ALL'], this.ssl)) {
         req.query.ssl = 'true';
       }
 
@@ -623,6 +627,13 @@ _.assign(derived, {
           server: {
             checkServerIdentity: false,
             sslValidate: false
+          }
+        });
+      } else if (this.ssl === 'IFAVAILABLE') {
+        _.assign(opts, {
+          server: {
+            checkServerIdentity: false,
+            sslValidate: true
           }
         });
       }
@@ -746,7 +757,7 @@ Connection = AmpersandModel.extend({
    * @param {Object} attrs - Incoming attributes.
    */
   validate_ssl: function(attrs) {
-    if (!attrs.ssl || _.includes(['NONE', 'UNVALIDATED'], attrs.ssl)) {
+    if (!attrs.ssl || _.includes(['NONE', 'UNVALIDATED', 'IFAVAILABLE'], attrs.ssl)) {
       return;
     }
     if (attrs.ssl === 'SERVER' && !attrs.ssl_ca) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -578,8 +578,10 @@ _.assign(derived, {
         });
       }
 
-      if (_.includes(['UNVALIDATED', 'IFAVAILABLE', 'SERVER', 'ALL'], this.ssl)) {
+      if (_.includes(['UNVALIDATED', 'SERVER', 'ALL'], this.ssl)) {
         req.query.ssl = 'true';
+      } else if (this.ssl === 'IFAVAILABLE') {
+        req.query.ssl = 'prefer';
       }
 
       return toURL(req);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -451,6 +451,25 @@ describe('mongodb-connection-model', function() {
       });
     });
 
+    describe('When ssl is IFAVAILABLE', function() {
+      var sslUnvalidated = new Connection({
+        ssl: 'IFAVAILABLE'
+      });
+
+      it('should produce the correct driver URL', function() {
+        assert.equal(sslUnvalidated.driver_url,
+          'mongodb://localhost:27017/?slaveOk=true&ssl=true');
+      });
+      it('should produce the correct driver options', function() {
+        var options = _.clone(Connection.DRIVER_OPTIONS_DEFAULT);
+        options.server = {
+          checkServerIdentity: false,
+          sslValidate: true
+        };
+        assert.deepEqual(sslUnvalidated.driver_options, options);
+      });
+    });
+
     describe('When ssl is SERVER', function() {
       var sslServer = new Connection({
         ssl: 'SERVER',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -442,13 +442,13 @@ describe('mongodb-connection-model', function() {
           'mongodb://localhost:27017/?slaveOk=true&ssl=true');
       });
       it('should produce the correct driver options', function() {
-        _.assign(options, {
-          server: {
-            checkServerIdentity: false,
-            sslValidate: false
-          }
-        });
+        var options = _.clone(Connection.DRIVER_OPTIONS_DEFAULT);
+        options.server = {
+          checkServerIdentity: false,
+          sslValidate: false
+        };
         assert.deepEqual(sslUnvalidated.driver_options, options);
+      });
     });
 
     describe('When ssl is SERVER', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -29,7 +29,7 @@ describe('mongodb-connection-model', function() {
       it('should return the correct URL for the driver', function() {
         var c = new Connection();
         assert.equal(c.driver_url,
-          'mongodb://localhost:27017/?slaveOk=true');
+          'mongodb://localhost:27017/?slaveOk=true&ssl=true');
 
         assert.doesNotThrow(function() {
           parse(c.driver_url);
@@ -88,7 +88,7 @@ describe('mongodb-connection-model', function() {
 
         it('should urlencode credentials', function() {
           assert.equal(c.driver_url,
-            'mongodb://%40rlo:w%40of@localhost:27017/?slaveOk=true&authSource=admin');
+            'mongodb://%40rlo:w%40of@localhost:27017/?slaveOk=true&authSource=admin&ssl=true');
         });
 
         it('should be parse in the browser', function() {
@@ -141,7 +141,7 @@ describe('mongodb-connection-model', function() {
 
           it('should urlencode credentials', function() {
             assert.equal(c.driver_url,
-              'mongodb://arlo:w%40of@localhost:27017/ldap?slaveOk=true&authMechanism=PLAIN');
+              'mongodb://arlo:w%40of@localhost:27017/ldap?slaveOk=true&authMechanism=PLAIN&ssl=true');
           });
 
           it('should be parse in the browser', function() {
@@ -188,7 +188,7 @@ describe('mongodb-connection-model', function() {
             assert.equal(c.driver_url,
               'mongodb://CN%253Dclient%252COU%253Darlo%252CO%253DMongoDB%252CL%253DPhiladelphia'
               + '%252CST%253DPennsylvania%252CC%253DUS@localhost:27017/'
-              + '?slaveOk=true&authMechanism=MONGODB-X509');
+              + '?slaveOk=true&authMechanism=MONGODB-X509&ssl=true');
           });
 
           it('should be parse in the browser', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -29,7 +29,7 @@ describe('mongodb-connection-model', function() {
       it('should return the correct URL for the driver', function() {
         var c = new Connection();
         assert.equal(c.driver_url,
-          'mongodb://localhost:27017/?slaveOk=true&ssl=true');
+          'mongodb://localhost:27017/?slaveOk=true&ssl=prefer');
 
         assert.doesNotThrow(function() {
           parse(c.driver_url);
@@ -88,7 +88,7 @@ describe('mongodb-connection-model', function() {
 
         it('should urlencode credentials', function() {
           assert.equal(c.driver_url,
-            'mongodb://%40rlo:w%40of@localhost:27017/?slaveOk=true&authSource=admin&ssl=true');
+            'mongodb://%40rlo:w%40of@localhost:27017/?slaveOk=true&authSource=admin&ssl=prefer');
         });
 
         it('should be parse in the browser', function() {
@@ -141,7 +141,7 @@ describe('mongodb-connection-model', function() {
 
           it('should urlencode credentials', function() {
             assert.equal(c.driver_url,
-              'mongodb://arlo:w%40of@localhost:27017/ldap?slaveOk=true&authMechanism=PLAIN&ssl=true');
+              'mongodb://arlo:w%40of@localhost:27017/ldap?slaveOk=true&authMechanism=PLAIN&ssl=prefer');
           });
 
           it('should be parse in the browser', function() {
@@ -188,7 +188,7 @@ describe('mongodb-connection-model', function() {
             assert.equal(c.driver_url,
               'mongodb://CN%253Dclient%252COU%253Darlo%252CO%253DMongoDB%252CL%253DPhiladelphia'
               + '%252CST%253DPennsylvania%252CC%253DUS@localhost:27017/'
-              + '?slaveOk=true&authMechanism=MONGODB-X509&ssl=true');
+              + '?slaveOk=true&authMechanism=MONGODB-X509&ssl=prefer');
           });
 
           it('should be parse in the browser', function() {
@@ -458,7 +458,7 @@ describe('mongodb-connection-model', function() {
 
       it('should produce the correct driver URL', function() {
         assert.equal(sslUnvalidated.driver_url,
-          'mongodb://localhost:27017/?slaveOk=true&ssl=true');
+          'mongodb://localhost:27017/?slaveOk=true&ssl=prefer');
       });
       it('should produce the correct driver options', function() {
         var options = _.clone(Connection.DRIVER_OPTIONS_DEFAULT);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -442,9 +442,13 @@ describe('mongodb-connection-model', function() {
           'mongodb://localhost:27017/?slaveOk=true&ssl=true');
       });
       it('should produce the correct driver options', function() {
-        assert.deepEqual(sslUnvalidated.driver_options,
-          Connection.DRIVER_OPTIONS_DEFAULT);
-      });
+        _.assign(options, {
+          server: {
+            checkServerIdentity: false,
+            sslValidate: false
+          }
+        });
+        assert.deepEqual(sslUnvalidated.driver_options, options);
     });
 
     describe('When ssl is SERVER', function() {


### PR DESCRIPTION
Using [`ssl=prefer`](https://mongodb.github.io/node-mongodb-native/driver-articles/mongoclient.html#connection-configuration) in the URL passed to the driver which:

> prefer: the driver tries to initiate each connection with SSL, and falls back to without SSL if it fails.

`ssl=IFAVAILABLE` also sets the driver options below to use the system certificate authority per INT-1709 :

```javascript
{
  server: {
    checkServerIdentity: false,
    sslValidate: true
  }
}
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/connection-model/109)
<!-- Reviewable:end -->
