### PR TITLE
INT-1771: Fix UncaughtException when not providing a required passphrase

### DIFF
--- a/lib/ssh-tunnel.js
+++ b/lib/ssh-tunnel.js
@@ -42,7 +42,7 @@ SSHTunnel.prototype.listen = function(done) {
     });
   }.bind(this));
 
-  this.__tunnel.on('listening', function() {
+  this._tunnel.on('listening', function() {
     this.emit('status', {
       message: 'Create SSH Tunnel',
       complete: true
@@ -51,7 +51,7 @@ SSHTunnel.prototype.listen = function(done) {
     done(null, true);
   }.bind(this));
 
-  this.__tunnel.on('error', function(err) {
+  this._tunnel.on('error', function(err) {
     debug('error setting up tunnel', err);
     this.emit('status', {
       message: 'Create SSH Tunnel',

--- a/lib/ssh-tunnel.js
+++ b/lib/ssh-tunnel.js
@@ -21,23 +21,43 @@ SSHTunnel.prototype.listen = function(done) {
     message: 'Create SSH Tunnel',
     pending: true
   });
+  /**
+   * Workaround a bug in `tunnel-ssh` where the error event is not
+   * handled.  This causes an UncaughtException in cases such as
+   * attempting to use a key which is passphrase protected.
+   *
+   * @see INT-1771
+   */
 
-  this._tunnel = createTunnel(this.model.ssh_tunnel_options, function(err) {
-    if (err) {
-      debug('error setting up tunnel', err);
-      this.emit('status', {
-        message: 'Create SSH Tunnel',
-        error: err
+  this._tunnel = createTunnel(this.model.ssh_tunnel_options, function() {
+    debug('tunnel-ssh called callback');
+  });
+
+  this._tunnel.on('netConnection', function(netConnection) {
+    var onError = this._tunnel.emit.bind(this.__tunnel, 'error');
+    netConnection.on('sshStream', function(sshStream) {
+      sshStream.on('error', function(err) {
+        onError(err);
       });
+    });
+  }.bind(this));
 
-      return done(err);
-    }
+  this.__tunnel.on('listening', function() {
     this.emit('status', {
       message: 'Create SSH Tunnel',
       complete: true
     });
 
     done(null, true);
+  }.bind(this));
+
+  this.__tunnel.on('error', function(err) {
+    debug('error setting up tunnel', err);
+    this.emit('status', {
+      message: 'Create SSH Tunnel',
+      error: err
+    });
+    done(err);
   }.bind(this));
 
   return this;

--- a/lib/ssh-tunnel.js
+++ b/lib/ssh-tunnel.js
@@ -34,7 +34,7 @@ SSHTunnel.prototype.listen = function(done) {
   });
 
   this._tunnel.on('netConnection', function(netConnection) {
-    var onError = this._tunnel.emit.bind(this.__tunnel, 'error');
+    var onError = this._tunnel.emit.bind(this._tunnel, 'error');
     netConnection.on('sshStream', function(sshStream) {
       sshStream.on('error', function(err) {
         onError(err);


### PR DESCRIPTION
Workaround a bug in `tunnel-ssh` where the error event is not handled.
This causes an UncaughtException in cases such as attempting to use a
key which is passphrase protected but not providing the passphrase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/connection-model/110)
<!-- Reviewable:end -->
