### PR TITLE
COMPASS-140: Restore SSL option - server and client validation

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -115,7 +115,8 @@ function getTasks(model) {
       return _statuses[message];
     }
 
-    var ctx = function(err) {
+    var ctx = function(err, opts) {
+      options = opts;
       if (err) {
         state.emit('status', {
           message: message,


### PR DESCRIPTION
Originally didn’t know why keeping the options = opts line around works, but it works and is now unit tested.
Found by the magical principle of git bisect.

[Probably no longer] CAVEATS:
1. Required connection-model@{master, currently v6.3.0}, i.e. where this commit is (probably would work anywhere on the 5.x series if we want to limit the number of changes to the 1.4.x stable branch if that isn't up to date).
2. Seemed to need data-service@1.4.0, but later found that upgrading to 2.0.0 seems fine too.
3. Works on 1.3-releases branch only so far, I get an “Auth failed” on 1.4-releases, so there’s at least one more regression!

EDIT: Later tracked down the “Auth failed” error into the hadron-build dependency. This turned out to be resolvable by running the “Master is broken” instructions, specifically:
npm run clean && npm install && COMPILE_CACHE=false npm start

Via:
https://github.com/10gen/compass#master-is-broken

This commit should now work on Compass master, 1.5-releases and 1.4-releases branches.
