### PR TITLE
COMPASS 443: Travis errors: Add mongodb-runner pretest and sudo: required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
-sudo: false
+sudo: required
 language: node_js
 node_js:
-- 6
+  - 6.3.1
+  - lts/boron
 script: npm run-script ci
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "browser": "browser.js",
   "scripts": {
     "ci": "npm run check && npm test",
+    "pretest": "mongodb-runner install",
     "test": "mocha",
     "fmt": "mongodb-js-fmt ./*.js lib/*.js ./test/*.js",
     "check": "mongodb-js-precommit"


### PR DESCRIPTION
Based on https://github.com/mongodb-js/index-model/commit/19eb5ce1b6e7ae41614e302ee99a624cca9701ce

Tested with the same Ubuntu VM @ 10% CPU execution cap scenario, this reproduces the `beforeAll` timeouts on master seen in https://github.com/mongodb-js/index-model/pull/53 and resolves them after (and for good measure in my testing, reproduces the errors again if you go back to the before state, clearing out all mongodb-version-manager test cache files and `killall mongod` as well).