### PR TITLE
COMPASS-527 close tunnel on error

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -194,6 +194,10 @@ function getTasks(model) {
       MongoClient.connect(model.driver_url, options, function(err, _db) {
         ctx(err);
         if (err) {
+          if (tunnel) {
+            debug('data-service connection error, shutting down ssh tunnel');
+            tunnel.close();
+          }
           return cb(err);
         }
         db = _db;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-config-mongodb-js": "^2.2.0",
     "mocha": "^3.1.2",
     "mock-require": "^2.0.1",
-    "mongodb-connection-fixture": "^0.0.13",
+    "mongodb-connection-fixture": "^0.0.14",
     "mongodb-instance-model": "^3.1.7",
     "mongodb-js-fmt": "^0.0.3",
     "mongodb-js-precommit": "^0.2.9",

--- a/package.json
+++ b/package.json
@@ -39,11 +39,13 @@
   "devDependencies": {
     "eslint-config-mongodb-js": "^2.2.0",
     "mocha": "^3.1.2",
+    "mock-require": "^2.0.1",
     "mongodb-connection-fixture": "^0.0.13",
     "mongodb-instance-model": "^3.1.7",
     "mongodb-js-fmt": "^0.0.3",
     "mongodb-js-precommit": "^0.2.9",
     "mongodb-runner": "^3.3.3",
-    "pre-commit": "^1.1.2"
+    "pre-commit": "^1.1.2",
+    "sinon": "^1.17.7"
   }
 }

--- a/test/connect.test.js
+++ b/test/connect.test.js
@@ -53,10 +53,12 @@ describe('mongodb-connection#connect', function() {
         });
         assert(model.isValid());
         mockConnect(model, function(err) {
-          if (err) {
-            assert.ok(spy.calledOnce);
-            done();
-          }
+          // must throw error here, because the connection details are invalid
+          assert.ok(err);
+          assert.ok(/failed to connect to server/.test(err.message));
+          // assert that tunnel.close() was called once
+          assert.ok(spy.calledOnce);
+          done();
         });
       });
     });

--- a/test/connect.test.js
+++ b/test/connect.test.js
@@ -63,18 +63,11 @@ describe('mongodb-connection#connect', function() {
   });
 
   describe('cloud #slow', function() {
-    const regex = /🔒  integrations@2.6 Cluster: /; // eslint-disable-line no-regex-spaces
+    this.slow(5000);
+    this.timeout(10000);
+
     data.MATRIX.map(function(d) {
       it(format('should connect to `%s`', d.name), function(done) {
-        if (regex.test(d.name)) {
-          console.log('Skipping test pending COMPASS-460');
-          console.log(regex);
-          this.skip();
-          return;
-        }
-        this.slow(5000);
-        this.timeout(10000);
-
         connect(d, function(err, _db) {
           if (err) {
             return done(err);
@@ -85,25 +78,14 @@ describe('mongodb-connection#connect', function() {
       });
     });
 
-    var find = function(_db, done) {
-      _db.db('mongodb').collection('fanclub').find({}, {
-        limit: 10
-      }, function(err, docs) {
-        if (err) {
-          return done(err);
-        }
-        assert.equal(docs.length, 10);
-        done();
-      });
-    };
-
     data.SSH_TUNNEL_MATRIX.map(function(d) {
       it('connects via the ssh_tunnel to ' + d.ssh_tunnel_hostname, function(done) {
         connect(d, function(err, _db) {
           if (err) {
             return done(err);
           }
-          find(_db, done);
+          _db.close();
+          done();
         });
       });
     });


### PR DESCRIPTION
When `MongoClient.connect()` returns error, make sure to close the ssh tunnel if it was created.