### PR TITLE
COMPASS-811: Drop misbehaving ‘instanceof’ check

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -3,7 +3,6 @@ var async = require('async');
 var _ = require('lodash');
 var MongoClient = require('mongodb').MongoClient;
 var parseURL = require('mongodb/lib/url_parser');
-var Connection = require('./model');
 var createSSHTunnel = require('./ssh-tunnel');
 var EventEmitter = require('events').EventEmitter;
 var debug = require('debug')('mongodb-connection-model:connect');
@@ -260,10 +259,6 @@ function getTasks(model) {
 }
 
 function connect(model, done) {
-  if (!(model instanceof Connection)) {
-    model = new Connection(model);
-  }
-
   if (!_.isFunction(done)) {
     done = function(err) {
       if (err) {

--- a/test/connect.test.js
+++ b/test/connect.test.js
@@ -12,6 +12,7 @@ var shouldGetInstanceDetails = function(db, done) {
 };
 
 var format = require('util').format;
+// TODO: These instances are now turned off
 var data = require('mongodb-connection-fixture');
 
 describe('mongodb-connection#connect', function() {
@@ -69,7 +70,7 @@ describe('mongodb-connection#connect', function() {
     this.timeout(10000);
 
     data.MATRIX.map(function(d) {
-      it(format('should connect to `%s`', d.name), function(done) {
+      it.skip(format('should connect to `%s`', d.name), function(done) {
         connect(d, function(err, _db) {
           if (err) {
             return done(err);
@@ -81,7 +82,7 @@ describe('mongodb-connection#connect', function() {
     });
 
     data.SSH_TUNNEL_MATRIX.map(function(d) {
-      it('connects via the ssh_tunnel to ' + d.ssh_tunnel_hostname, function(done) {
+      it.skip('connects via the ssh_tunnel to ' + d.ssh_tunnel_hostname, function(done) {
         connect(d, function(err, _db) {
           if (err) {
             return done(err);

--- a/test/connect.test.js
+++ b/test/connect.test.js
@@ -11,7 +11,6 @@ var shouldGetInstanceDetails = function(db, done) {
   Instance.fetch(db, done);
 };
 
-var format = require('util').format;
 // TODO: These instances are now turned off
 var data = require('mongodb-connection-fixture');
 
@@ -70,7 +69,7 @@ describe('mongodb-connection#connect', function() {
     this.timeout(10000);
 
     data.MATRIX.map(function(d) {
-      it.skip(format('should connect to `%s`', d.name), function(done) {
+      it.skip('should connect to ' + d.name, function(done) {
         connect(d, function(err, _db) {
           if (err) {
             return done(err);


### PR DESCRIPTION
BEFORE

![authentication failed](https://cloud.githubusercontent.com/assets/1217010/23290902/786c5170-faa8-11e6-9c7a-88f6e326c5ea.png)

AFTER, it allows you to connect 👍 

It looks like the `instanceof` check does not work for Ampersand models. This causes the `mongodb_username` and `mongodb_password` attributes of a `Connection` to be silently dropped, causing auth to fail.

### More details and steps to reproduce

Doesn’t shed much light on this:
https://github.com/mongodb-js/connection-model/commit/3f0896f27c44e56047288c192f7e2ff2f1b7154e

In my scenario, I have set up a local mongod with auth enabled, based on:
https://docs.mongodb.com/master/tutorial/enable-authentication/

Steps to reproduce:
0. mongodb enterprise v3.4.2
1. Create a new folder, and create a data/db folder inside that folder, e.g.

mkdir -p tickets/COMPASS-811
cd tickets/COMPASS-811
mkdir -p data/db

2. Add to mongod.conf in a new folder (so you don’t reuse any existing mongod instances):

storage:
   dbPath: data/db

security:
  authorization: enabled

3. Start mongod:
mongod --config mongod.conf

4. At a mongo shell, first use localhost exception to create a root user:

$ mongo
MongoDB shell version v3.4.2
connecting to: mongodb://127.0.0.1:27017
MongoDB server version: 3.4.2
MongoDB Enterprise > use admin
switched to db admin
MongoDB Enterprise > db.createUser({user: 'root', pwd: 'root', roles: ['root']})

5. Authenticate as that root user:

MongoDB Enterprise > db.auth('root', 'root')

6. Create a read-only user:

MongoDB Enterprise > db.createUser({user: 'read', pwd: 'a', roles: ['readAnyDatabase']})

7. (Optional) Verify that user can log in with a new mongo shell:

$ mongo --username read --password a --authenticationDatabase admin
MongoDB shell version v3.4.2
connecting to: mongodb://127.0.0.1:27017
MongoDB server version: 3.4.2
MongoDB Enterprise > show dbs
admin  0.000GB
local  0.000GB
MongoDB Enterprise >

8. Try the ‘read’ user in Compass. It should give “Authentication failed.” error message, until this fix is applied (and propagated into [data-service](https://github.com/mongodb-js/data-service), e.g. the easiest way to test this is to edit the file `compass/node_modules/mongodb-data-service/node_modules/mongodb-connection-model/lib/connect.js`).