### PR TITLE
COMPASS-829 add app name property

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ var Connection = require('mongodb-connection-model');
 - `port` (optional, Number) ... TCP port of a MongoDB Instance [Default: `27017`].
 - `name` (optional, String) ... User specified name [Default: `My MongoDB`].
 - `ns` (optional, String) ... A valid [ns][ns] the user can read from [Default: `undefined`].
+- `app_name` (optional, String) ... An application name passed to server as client metadata [Default: `undefined`].
 
 ## Derived Properties
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -51,6 +51,10 @@ _.assign(props, {
   ns: {
     type: 'string',
     default: undefined
+  },
+  app_name: {
+    type: 'string',
+    default: undefined
   }
 });
 
@@ -547,6 +551,7 @@ _.assign(derived, {
       'port',
       'ssl',
       'ssh_tunnel',
+      'app_name',
       'kerberos_principal',
       'kerberos_password',
       'kerberos_service_name',
@@ -566,6 +571,10 @@ _.assign(derived, {
           slaveOk: 'true'
         }
       };
+
+      if (this.app_name) {
+        req.query.appname = this.app_name;
+      }
 
       if (this.ns) {
         req.pathname = format('/%s', this.ns);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -26,6 +26,23 @@ function isNotValidAndHasMessage(model, msg) {
  * that a user may need.
  */
 describe('mongodb-connection-model', function() {
+  describe('client meta data', function() {
+    it('should return the correct URL with appname included', function() {
+      var c = new Connection({
+        app_name: 'My App'
+      });
+      assert.equal(c.driver_url,
+        'mongodb://localhost:27017/?slaveOk=true&appname=My%20App');
+
+      assert.doesNotThrow(function() {
+        parse(c.driver_url);
+      });
+
+      assert.doesNotThrow(function() {
+        driverParse(c.driver_url);
+      });
+    });
+  });
   describe('authentication', function() {
     describe('NONE', function() {
       it('should return the correct URL for the driver', function() {


### PR DESCRIPTION
A quick fix for something that has been bugging me but is never important enough to be scheduled:

Allow passing in application name which will be passed to the server and appear in log files and profiling collections. See https://docs.mongodb.com/manual/reference/log-messages/#client-data

