### PR TITLE
COMPASS 830: Use a more general PASSWORD check for Atlas

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1009,7 +1009,7 @@ Connection.from = function(url) {
 Connection._improveAtlasDefaults = function(url, mongodb_password) {
   var atlasConnectionAttrs = {};
   if (Connection.isAtlas(url)) {
-    atlasConnectionAttrs.ssl = 'UNVALIDATED';
+    atlasConnectionAttrs.ssl = 'SYSTEMCA';
     if (mongodb_password.length <= 20 &&
         mongodb_password.toUpperCase().indexOf('PASSWORD') > -1) {
       atlasConnectionAttrs.mongodb_password = '';

--- a/lib/model.js
+++ b/lib/model.js
@@ -1000,8 +1000,9 @@ Connection.from = function(url) {
  * Helper function to improve the Atlas user experience by
  * providing better default values.
  *
- * @param {String} url  The connection string URL.
- * @param {String} mongodb_password  The
+ * @param {String} url - The connection string URL.
+ * @param {String} mongodb_password - The mongodb_password
+ *   which the user may need to change.
  * @returns {Object} Connection attributes to override
  * @private
  */
@@ -1009,7 +1010,8 @@ Connection._improveAtlasDefaults = function(url, mongodb_password) {
   var atlasConnectionAttrs = {};
   if (Connection.isAtlas(url)) {
     atlasConnectionAttrs.ssl = 'UNVALIDATED';
-    if (mongodb_password === 'PASSWORD') {
+    if (mongodb_password.length <= 20 &&
+        mongodb_password.toUpperCase().indexOf('PASSWORD') > -1) {
       atlasConnectionAttrs.mongodb_password = '';
     }
   }

--- a/lib/model.js
+++ b/lib/model.js
@@ -221,6 +221,7 @@ _.assign(props, {
 });
 
 var MONGODB_DATABASE_NAME_DEFAULT = 'admin';
+var MONGODB_NAMESPACE_DEFAULT = 'test';
 
 /**
  * ### `authentication = KERBEROS`
@@ -990,7 +991,7 @@ Connection.from = function(url) {
       attrs.mongodb_database_name = decodeURIComponent(
         parsed.db_options.authSource || parsed.dbName);
     }
-    _.assign(attrs, Connection._improveAtlasDefaults(url, attrs.mongodb_password));
+    Object.assign(attrs, Connection._improveAtlasDefaults(url, attrs.mongodb_password, attrs.ns));
   }
 
   return new Connection(attrs);
@@ -1003,15 +1004,19 @@ Connection.from = function(url) {
  * @param {String} url - The connection string URL.
  * @param {String} mongodb_password - The mongodb_password
  *   which the user may need to change.
+ * @param {String} namespace - The namespace (ns) to connect to.
  * @returns {Object} Connection attributes to override
  * @private
  */
-Connection._improveAtlasDefaults = function(url, mongodb_password) {
+Connection._improveAtlasDefaults = function(url, mongodb_password, namespace) {
   var atlasConnectionAttrs = {};
   if (Connection.isAtlas(url)) {
     atlasConnectionAttrs.ssl = 'SYSTEMCA';
     if (mongodb_password.match(/^.?PASSWORD.?$/i)) {
       atlasConnectionAttrs.mongodb_password = '';
+    }
+    if (namespace.match(/^.?DATABASE.?$/i)) {
+      atlasConnectionAttrs.ns = Connection.MONGODB_NAMESPACE_DEFAULT;
     }
   }
   return atlasConnectionAttrs;
@@ -1042,6 +1047,7 @@ Connection.SSL_VALUES = SSL_VALUES;
 Connection.SSL_DEFAULT = SSL_DEFAULT;
 Connection.SSH_TUNNEL_VALUES = SSH_TUNNEL_VALUES;
 Connection.SSH_TUNNEL_DEFAULT = SSH_TUNNEL_DEFAULT;
+Connection.MONGODB_NAMESPACE_DEFAULT = MONGODB_NAMESPACE_DEFAULT;
 Connection.MONGODB_DATABASE_NAME_DEFAULT = MONGODB_DATABASE_NAME_DEFAULT;
 Connection.KERBEROS_SERVICE_NAME_DEFAULT = KERBEROS_SERVICE_NAME_DEFAULT;
 Connection.DRIVER_OPTIONS_DEFAULT = DRIVER_OPTIONS_DEFAULT;

--- a/lib/model.js
+++ b/lib/model.js
@@ -1010,8 +1010,7 @@ Connection._improveAtlasDefaults = function(url, mongodb_password) {
   var atlasConnectionAttrs = {};
   if (Connection.isAtlas(url)) {
     atlasConnectionAttrs.ssl = 'SYSTEMCA';
-    if (mongodb_password.length <= 20 &&
-        mongodb_password.toUpperCase().indexOf('PASSWORD') > -1) {
+    if (mongodb_password.match(/^.?PASSWORD.?$/i)) {
       atlasConnectionAttrs.mongodb_password = '';
     }
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -145,6 +145,11 @@ describe('mongodb-connection-model', function() {
         assert.equal(c.ssl, 'SYSTEMCA');
         assert.equal(c.mongodb_password, userPass);
       });
+      it('changes the <DATABASE> namespace to test', function() {
+        assert.ok(atlasConnection.indexOf('<DATABASE>') > -1);
+        var c = Connection.from(atlasConnection);
+        assert.equal(c.ns, 'test');
+      });
       it('does not false positive on hi.mongodb.net.my.domain.com', function() {
         var c = Connection.from(
             atlasConnection.replace(/mongodb.net/g, 'hi.mongodb.net.my.domain.com'));

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -110,11 +110,16 @@ describe('mongodb-connection-model', function() {
     });
 
     describe('ATLAS - mongodb.net', function() {
-      var atlasConnection = 'mongodb://ADMINUSER:PASSWORD@' +
+      var atlasConnection = 'mongodb://ADMINUSER:<PASSWORD>@' +
           'a-compass-atlas-test-shard-00-00-vll9l.mongodb.net:38128,' +
           'a-compass-atlas-test-shard-00-01-vll9l.mongodb.net:38128,' +
           'a-compass-atlas-test-shard-00-02-vll9l.mongodb.net:38128/admin?' +
           'ssl=true&replicaSet=a-compass-atlas-test-shard-0&authSource=admin';
+      var okAtlasPassword = 'A_MUCH_LONGER_PASSWORD_should_be_more secure...';
+      var okAtlasPasswordConnection = atlasConnection.replace(
+        '<PASSWORD>',
+        okAtlasPassword
+      );
       it('defaults SSL to UNVALIDATED', function() {
         var c = Connection.from(atlasConnection);
         // In future, we should ship our own CA with Compass
@@ -122,7 +127,7 @@ describe('mongodb-connection-model', function() {
         // This is a step in the right direction so let's take the easy wins.
         assert.equal(c.ssl, 'UNVALIDATED');
       });
-      it('clears the default PASSWORD', function() {
+      it('clears the default <PASSWORD>', function() {
         // UX: We clear the default string 'PASSWORD' from the Atlas GUI
         // so the user is forced to enter their own password
         // rather than getting trapped with the error:
@@ -130,9 +135,13 @@ describe('mongodb-connection-model', function() {
         var c = Connection.from(atlasConnection);
         assert.equal(c.mongodb_password, '');
       });
+      it('does not clear sufficiently long passwords that happen to contain PASSWORD', function() {
+        var c = Connection.from(okAtlasPasswordConnection);
+        assert.equal(c.mongodb_password, okAtlasPassword);
+      });
       it('works with a non-default secure password', function() {
         var userPass = '6NuZPtHCrjYBAWnI7Iq6jvtsdJx67X0';
-        var c = Connection.from(atlasConnection.replace('PASSWORD', userPass));
+        var c = Connection.from(atlasConnection.replace('<PASSWORD>', userPass));
         assert.equal(c.ssl, 'UNVALIDATED');
         assert.equal(c.mongodb_password, userPass);
       });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -113,7 +113,7 @@ describe('mongodb-connection-model', function() {
       var atlasConnection = 'mongodb://ADMINUSER:<PASSWORD>@' +
           'a-compass-atlas-test-shard-00-00-vll9l.mongodb.net:38128,' +
           'a-compass-atlas-test-shard-00-01-vll9l.mongodb.net:38128,' +
-          'a-compass-atlas-test-shard-00-02-vll9l.mongodb.net:38128/admin?' +
+          'a-compass-atlas-test-shard-00-02-vll9l.mongodb.net:38128/<DATABASE>?' +
           'ssl=true&replicaSet=a-compass-atlas-test-shard-0&authSource=admin';
       var okAtlasPassword = 'A_MUCH_LONGER_PASSWORD_should_be_more secure...';
       var okAtlasPasswordConnection = atlasConnection.replace(

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -120,12 +120,12 @@ describe('mongodb-connection-model', function() {
         '<PASSWORD>',
         okAtlasPassword
       );
-      it('defaults SSL to UNVALIDATED', function() {
+      it('defaults SSL to SYSTEMCA', function() {
         var c = Connection.from(atlasConnection);
         // In future, we should ship our own CA with Compass
         // so we can default to 'SERVER'-validated.
         // This is a step in the right direction so let's take the easy wins.
-        assert.equal(c.ssl, 'UNVALIDATED');
+        assert.equal(c.ssl, 'SYSTEMCA');
       });
       it('clears the default <PASSWORD>', function() {
         // UX: We clear the default string 'PASSWORD' from the Atlas GUI
@@ -142,7 +142,7 @@ describe('mongodb-connection-model', function() {
       it('works with a non-default secure password', function() {
         var userPass = '6NuZPtHCrjYBAWnI7Iq6jvtsdJx67X0';
         var c = Connection.from(atlasConnection.replace('<PASSWORD>', userPass));
-        assert.equal(c.ssl, 'UNVALIDATED');
+        assert.equal(c.ssl, 'SYSTEMCA');
         assert.equal(c.mongodb_password, userPass);
       });
       it('does not false positive on hi.mongodb.net.my.domain.com', function() {
@@ -152,7 +152,7 @@ describe('mongodb-connection-model', function() {
       });
       it('is case insensitive, see RFC4343', function() {
         var c = Connection.from(atlasConnection.replace(/mongodb.net/g, 'mOnGOdB.NeT'));
-        assert.equal(c.ssl, 'UNVALIDATED');
+        assert.equal(c.ssl, 'SYSTEMCA');
       });
     });
 


### PR DESCRIPTION
Atlas updated their copy/paste connection string:

<img width="645" alt="example new connection string password" src="https://cloud.githubusercontent.com/assets/1217010/23441021/eadf6e76-fe73-11e6-8403-714260feeb02.png">

Hence we should support the new version in Compass.

While in the area, this also updates the default Atlas SSL option from UNVALIDATED to SYSTEMCA, so in future we won't need to override it in as many places in Compass itself.