### PR TITLE
COMPASS-745 LDAP @ in username gets double encoded

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -605,7 +605,7 @@ _.assign(derived, {
         });
       } else if (this.authentication === 'LDAP') {
         req.auth = format('%s:%s',
-          encodeURIComponent(this.ldap_username),
+          this.ldap_username,
           this.ldap_password);
 
         _.defaults(req.query, {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -230,6 +230,19 @@ describe('mongodb-connection-model', function() {
             });
           });
         });
+
+        describe('driver_url with @', function() {
+          var c = new Connection({
+            authentication: 'LDAP',
+            ldap_username: 'arlo@t.co',
+            ldap_password: 'woof',
+            ns: 'ldap'
+          });
+          it('COMPASS-745 - should urlencode @ once only', function() {
+            assert.equal(c.driver_url,
+              'mongodb://arlo%40t.co:woof@localhost:27017/ldap?slaveOk=true&authMechanism=PLAIN');
+          });
+        });
       });
 
       describe('X509', function() {


### PR DESCRIPTION
This PR adds a test and fix for `@` being double-encoded to `%2540` in mongoDB URLs which are passed along, for instance to the node driver.

BEFORE

![authentication failed if username contains](https://cloud.githubusercontent.com/assets/1217010/23600389/82f39e92-029a-11e7-82a7-c7db7577b5d4.png)


AFTER

<img width="1279" alt="after" src="https://cloud.githubusercontent.com/assets/1217010/23600384/7f527eac-029a-11e7-95ab-2bb35d2c4b35.png">

Note: It looks like Kerberos and X.509 are also affected by this. We don't support X.509 in Compass (yet) and will investigate Kerberos on COMPASS 851.