### PR TITLE
COMPASS-1013 add extra options

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ var c = new Connection({
 console.log(c.driver_url)
 >>> 'mongodb://arlo:w%40of@localhost:27017/?slaveOk=true&authSource=admin'
 console.log(c.driver_options)
->>> { uri_decode_auth: true,
-  db: { readPreference: 'nearest' },
+>>> { db: { readPreference: 'nearest' },
   replSet: { connectWithNoPrimary: true } }
 ```
 
@@ -102,8 +101,7 @@ console.log(c.driver_options)
  console.log(c.driver_url)
  >>> 'mongodb://arlo%252Fdog%2540krb5.mongodb.parts:w%40%40f@localhost:27017/toys?slaveOk=true&gssapiServiceName=mongodb&authMechanism=GSSAPI'
  console.log(c.driver_options)
- >>> { uri_decode_auth: true,
-   db: { readPreference: 'nearest' },
+ >>> { db: { readPreference: 'nearest' },
    replSet: { connectWithNoPrimary: true } }
 ```
 
@@ -141,9 +139,8 @@ var c = new Connection({
 console.log(c.driver_url)
 >>> 'mongodb://CN%253Dclient%252COU%253Darlo%252CO%253DMongoDB%252CL%253DPhiladelphia%252CST%253DPennsylvania%252CC%253DUS@localhost:27017?slaveOk=true&authMechanism=MONGODB-X509'
 console.log(c.driver_options)
->>> { uri_decode_auth: true,
-db: { readPreference: 'nearest' },
-replSet: { connectWithNoPrimary: true } }
+>>> { db: { readPreference: 'nearest' },
+  replSet: { connectWithNoPrimary: true } }
 ```
 
 <a name="authentication-ldap"></a>
@@ -168,9 +165,8 @@ var c = new Connection({
 console.log(c.driver_url)
 >>> 'mongodb://arlo:w%40of@localhost:27017/toys?slaveOk=true&authMechanism=PLAIN'
 console.log(c.driver_options)
->>> { uri_decode_auth: true,
- db: { readPreference: 'nearest' },
- replSet: { connectWithNoPrimary: true } }
+>>> { db: { readPreference: 'nearest' },
+  replSet: { connectWithNoPrimary: true } }
 ```
 
 ### Trait: SSL

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ var Connection = require('mongodb-connection-model');
 - `name` (optional, String) ... User specified name [Default: `My MongoDB`].
 - `ns` (optional, String) ... A valid [ns][ns] the user can read from [Default: `undefined`].
 - `app_name` (optional, String) ... An application name passed to server as client metadata [Default: `undefined`].
+- `extra_options` (optional, Object) ... Extra options passed to the node driver as part of `driver_options` [Default: `{}`].
 
 ## Derived Properties
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -640,7 +640,6 @@ _.assign(derived, {
    * @return {Object}
    */
   driver_options: {
-      'prmote_values'
     deps: [
       'ssl',
       'ssl_ca',
@@ -648,6 +647,7 @@ _.assign(derived, {
       'ssl_private_key',
       'ssl_private_key_password',
       'extra_options',
+      'promote_values'
     ],
     fn: function() {
       var opts = _.clone(DRIVER_OPTIONS_DEFAULT, true);

--- a/lib/model.js
+++ b/lib/model.js
@@ -55,6 +55,12 @@ _.assign(props, {
   app_name: {
     type: 'string',
     default: undefined
+  },
+  extra_options: {
+    type: 'object',
+    default: function() {
+      return {};
+    }
   }
 });
 
@@ -634,13 +640,14 @@ _.assign(derived, {
    * @return {Object}
    */
   driver_options: {
+      'prmote_values'
     deps: [
       'ssl',
       'ssl_ca',
       'ssl_certificate',
       'ssl_private_key',
       'ssl_private_key_password',
-      'prmote_values'
+      'extra_options',
     ],
     fn: function() {
       var opts = _.clone(DRIVER_OPTIONS_DEFAULT, true);
@@ -687,6 +694,9 @@ _.assign(derived, {
         });
       }
       opts.db.promoteValues = this.promote_values;
+
+      // assign and overwrite all extra options provided by user
+      _.assign(opts, this.extra_options);
       return opts;
     }
   },

--- a/lib/model.js
+++ b/lib/model.js
@@ -197,8 +197,7 @@ var AUTHENTICATION_TO_FIELD_NAMES = {
  *   console.log(c.driver_url)
  *   >>> mongodb://arlo:w%40of@localhost:27017?slaveOk=true&authSource=admin
  *   console.log(c.driver_options)
- *   >>> { uri_decode_auth: true,
- *     db: { readPreference: 'nearest' },
+ *   >>> { db: { readPreference: 'nearest' },
  *     replSet: { connectWithNoPrimary: true } }
  */
 _.assign(props, {
@@ -246,8 +245,7 @@ var MONGODB_NAMESPACE_DEFAULT = 'test';
  *   console.log(c.driver_url)
  *   >>> mongodb://arlo%252Fdog%2540krb5.mongodb.parts:w%40%40f@localhost:27017/kerberos?slaveOk=true&gssapiServiceName=mongodb&authMechanism=GSSAPI
  *   console.log(c.driver_options)
- *   >>> { uri_decode_auth: true,
- *     db: { readPreference: 'nearest' },
+ *   >>> { db: { readPreference: 'nearest' },
  *     replSet: { connectWithNoPrimary: true } }
  *
  * @enterprise
@@ -308,8 +306,7 @@ var KERBEROS_SERVICE_NAME_DEFAULT = 'mongodb';
  *   console.log(c.driver_url)
  *   >>> mongodb://arlo:w%40of@localhost:27017/ldap?slaveOk=true&authMechanism=PLAIN
  *   console.log(c.driver_options)
- *   >>> { uri_decode_auth: true,
- *     db: { readPreference: 'nearest' },
+ *   >>> { db: { readPreference: 'nearest' },
  *     replSet: { connectWithNoPrimary: true } }
  *
  * @enterprise
@@ -349,8 +346,7 @@ _.assign(props, {
  *   console.log(c.driver_url)
  *   >>> mongodb://CN%253Dclient%252COU%253Darlo%252CO%253DMongoDB%252CL%253DPhiladelphia%252CST%253DPennsylvania%252CC%253DUS@localhost:27017?slaveOk=true&authMechanism=MONGODB-X509
  *   console.log(c.driver_options)
- *   >>> { uri_decode_auth: true,
- *    db: { readPreference: 'nearest' },
+ *   >>> { db: { readPreference: 'nearest' },
  *    replSet: { connectWithNoPrimary: true } }
  *
  * @see http://bit.ly/mongodb-node-driver-x509
@@ -536,7 +532,6 @@ _.assign(props, {
  * `MongoClient.connect(model.driver_url, model.driver_options)`.
  */
 var DRIVER_OPTIONS_DEFAULT = {
-  uri_decode_auth: true,
   db: {
     // important!  or slaveOk=true set above no worky!
     readPreference: 'secondaryPreferred'

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -480,6 +480,30 @@ describe('mongodb-connection-model', function() {
     });
   });
 
+  describe('extra_options', function() {
+    describe('When not specifying any extra_options', function() {
+      var conn = new Connection();
+
+      it('should use default driver_options', function() {
+        assert.ok(!_.has(conn.driver_options, 'connectTimeoutMS'));
+        assert.ok(!_.has(conn.driver_options, 'socketTimeoutMS'));
+      });
+    });
+    describe('When specifying custom extra_options', function() {
+      var conn = new Connection({
+        extra_options: {
+          socketTimeoutMS: 1000
+        }
+      });
+
+      it('should include the extra_options in driver_options', function() {
+        var options = _.clone(Connection.DRIVER_OPTIONS_DEFAULT);
+        options.socketTimeoutMS = 1000;
+        assert.deepEqual(conn.driver_options, options);
+      });
+    });
+  });
+
   describe('ssl', function() {
     describe('load', function() {
       it('should load all of the files from the filesystem', function(done) {


### PR DESCRIPTION
as part of COMPASS-1013, we need to add the ability to customize the driver options, e.g. specifying `connectTimeoutMS` and `socketTimeoutMS` for connections.

This change adds a new property `extra_options` to the model, which will be merged into the derived property `driver_options`.

See added tests for usage.

Another change: I removed the now obsolete `uri_decode_auth` option, which causes warnings in Compass. This option [was removed from the node driver](https://github.com/mongodb/node-mongodb-native/pull/1488) in version 2.2.25. It now always decodes the auth credentials.

Finally, there was also a small typo in the deps for `driver_options` which is fixed now.