### PR TITLE
COMPASS-915: Remove Promote Values from Connection Model

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -219,13 +219,6 @@ _.assign(props, {
   mongodb_database_name: {
     type: 'string',
     default: undefined
-  },
-  /**
-   * Whether BSON values should be promoted to their JS type counterparts.
-   */
-  promote_values: {
-    type: 'boolean',
-    default: true
   }
 });
 
@@ -688,10 +681,10 @@ _.assign(derived, {
           }
         });
       }
-      opts.db.promoteValues = this.promote_values;
 
       // assign and overwrite all extra options provided by user
       _.assign(opts, this.extra_options);
+
       return opts;
     }
   },

--- a/lib/model.js
+++ b/lib/model.js
@@ -219,6 +219,12 @@ _.assign(props, {
   mongodb_database_name: {
     type: 'string',
     default: undefined
+  },
+  /**
+   * Whether BSON values should be promoted to their JS type counterparts.
+   */
+  promote_values: {
+    type: 'boolean'
   }
 });
 
@@ -684,6 +690,11 @@ _.assign(derived, {
 
       // assign and overwrite all extra options provided by user
       _.assign(opts, this.extra_options);
+
+      // only set promoteValues if it is defined
+      if (this.promote_values !== undefined) {
+        opts.db.promoteValues = this.promote_values;
+      }
 
       return opts;
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -504,6 +504,28 @@ describe('mongodb-connection-model', function() {
     });
   });
 
+  describe('promote_values', function() {
+    describe('when no promote_values provided', function() {
+      var conn = new Connection();
+
+      it('should not have promoteValues specified', function() {
+        assert.ok(!_.has(conn.driver_options.db.promoteValues));
+      });
+    });
+    describe('when including promoteValues as true in connection', function() {
+      var conn = new Connection({promote_values: true});
+      it('should have the same value in driver options', function() {
+        assert.equal(conn.driver_options.db.promoteValues, true);
+      });
+    });
+    describe('when including promoteValues as false in connection', function() {
+      var conn = new Connection({promote_values: false});
+      it('should have the same value in driver options', function() {
+        assert.equal(conn.driver_options.db.promoteValues, false);
+      });
+    });
+  });
+
   describe('ssl', function() {
     describe('load', function() {
       it('should load all of the files from the filesystem', function(done) {


### PR DESCRIPTION
This PR removes `promote_values` prop from connection model. As it is no longer necessary for CRUD actions. Having this here adds `promoteValues` to the connection state which interferes with the node driver's cursor; prematurely setting `topologyOptions.promoteValues` to true [here](https://github.com/christkv/mongodb-core/blob/9cf1dd46595bcaf5b9ef5227bbdd679247def750/lib/cursor.js#L116-L120).
![screen shot 2017-04-19 at 10 22 31 am](https://cloud.githubusercontent.com/assets/4054185/25164216/df567c14-2512-11e7-9d1d-c1582bc626ca.png)

By the time the connection is set to data-service  (see above)  there's already a preference (i.e. favouring toplogyOptions) which overrides any direct queries sent to the node driver.

I'm not entirely sure what `topologyOptions` refers to [from the link above](https://github.com/christkv/mongodb-core/blob/9cf1dd46595bcaf5b9ef5227bbdd679247def750/lib/cursor.js#L116-L120) because it is preferred over `options`. Based on the [SDAM document](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#topology)
It refers to the state of a particular deployment. If that's the case though I don't know why COMPASS-915 seems to only affect Atlas instances.

Long story short, removing promote_values and not setting it directly to the `opts` object fixes COMPASS-915.

Edit: as per @rueckstiess review it's better to not remove `promoteValues` completely instead remove the default value of true so the existing behaviour doesn't change.