### PR TITLE
COMPASS-972: Cannot authenticate if username or password contains a ":" or emoji

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -583,7 +583,7 @@ _.assign(derived, {
 
       const encodeAuthForUrlFormat = () => {
         if (this.authentication === 'MONGODB') {
-          req.auth = format('%s:%s', this.mongodb_username, this.mongodb_password);
+          req.auth = 'TOKEN';
           req.query.authSource = this.mongodb_database_name;
         } else if (this.authentication === 'KERBEROS') {
           _.defaults(req.query, {
@@ -627,7 +627,20 @@ _.assign(derived, {
         reqClone.hostname = this.ssh_tunnel_options.localAddr;
         reqClone.port = this.ssh_tunnel_options.localPort;
       }
-      return toURL(reqClone);
+      var result = toURL(reqClone);
+
+      // Post url.format() workaround for
+      // https://github.com/nodejs/node/issues/1802
+      if (this.authentication === 'MONGODB') {
+        var newAuth = format('%s:%s',
+          encodeURIComponent(this.mongodb_username),
+          encodeURIComponent(this.mongodb_password));
+
+        // The auth component comes straight after the mongodb:// so
+        // a single string replace should always work
+        result = result.replace('TOKEN', newAuth, 1);
+      }
+      return result;
     }
   },
   /**

--- a/lib/model.js
+++ b/lib/model.js
@@ -562,6 +562,7 @@ _.assign(derived, {
       'driver_auth_mechanism'
     ],
     fn: function() {
+      const AUTH_TOKEN = 'AUTH_TOKEN';
       var req = {
         protocol: 'mongodb',
         slashes: true,
@@ -583,7 +584,7 @@ _.assign(derived, {
 
       const encodeAuthForUrlFormat = () => {
         if (this.authentication === 'MONGODB') {
-          req.auth = 'TOKEN';
+          req.auth = AUTH_TOKEN;
           req.query.authSource = this.mongodb_database_name;
         } else if (this.authentication === 'KERBEROS') {
           _.defaults(req.query, {
@@ -638,7 +639,7 @@ _.assign(derived, {
 
         // The auth component comes straight after the mongodb:// so
         // a single string replace should always work
-        result = result.replace('TOKEN', newAuth, 1);
+        result = result.replace(AUTH_TOKEN, newAuth, 1);
       }
       return result;
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -158,6 +158,40 @@ describe('mongodb-connection-model', function() {
           });
         });
       });
+
+      describe('with emoji', () => {
+        let username;
+        let password;
+        let connection;
+        let authExpect;
+
+        before(() => {
+          username = '👌emoji😂😍😘🔥💕🎁💯🌹';
+          password = '👌emoji😂😍😘🔥💕🎁💯🌹';
+          connection = new Connection({
+            mongodb_username: username,
+            mongodb_password: password
+          });
+          authExpect = `${encodeURIComponent(username)}:${encodeURIComponent(password)}`;
+        });
+
+        it('should urlencode credentials', () => {
+          assert.equal(connection.driver_url,
+            `mongodb://${authExpect}@localhost:27017/?slaveOk=true&authSource=admin`);
+        });
+
+        it('should be parse in the browser', () => {
+          assert.doesNotThrow(() => {
+            parse(connection.driver_url);
+          });
+        });
+
+        it('should parse on the server', () => {
+          assert.doesNotThrow(() => {
+            driverParse(connection.driver_url);
+          });
+        });
+      });
     });
 
     describe('ATLAS - mongodb.net', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -124,6 +124,40 @@ describe('mongodb-connection-model', function() {
           });
         });
       });
+
+      describe('with special characters e.g. colon', () => {
+        let username;
+        let password;
+        let connection;
+        let authExpect;
+
+        before(() => {
+          username = 'user@-azMPk]&3Wt)iP_9C:PMQ=';
+          password = 'user@-azMPk]&3Wt)iP_9C:PMQ=';
+          connection = new Connection({
+            mongodb_username: username,
+            mongodb_password: password
+          });
+          authExpect = `${encodeURIComponent(username)}:${encodeURIComponent(password)}`;
+        });
+
+        it('should urlencode credentials', () => {
+          assert.equal(connection.driver_url,
+            `mongodb://${authExpect}@localhost:27017/?slaveOk=true&authSource=admin`);
+        });
+
+        it('should be parse in the browser', () => {
+          assert.doesNotThrow(() => {
+            parse(connection.driver_url);
+          });
+        });
+
+        it('should parse on the server', () => {
+          assert.doesNotThrow(() => {
+            driverParse(connection.driver_url);
+          });
+        });
+      });
     });
 
     describe('ATLAS - mongodb.net', function() {


### PR DESCRIPTION
⚠️ This is built on top of #174 to make it easier to review. 

This PR applies the node builtin `encodeURIComponent` manually to the auth username and password sections, allowing MongoDB users in downstream applications to authenticate if their username or password contains characters such as `:` or 👌emoji😂😍😘🔥💕🎁💯🌹.

See also the upstream node issue:
nodejs/node#1802

Note: I also considered the following alternative which would be RFC3986-compliant, but found it had significantly higher latency, see:
http://mongodb.github.io/node-mongodb-native/2.2/api/Db.html#authenticate
https://tools.ietf.org/html/rfc3986#section-3.2.1
