### PR TITLE
CHARTS-306: Support atlas/on-prem connections for Stitch in connection-model

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -571,6 +571,15 @@ _.assign(props, {
 });
 
 /**
+ * @constant {Object} - Allowed values for the 'connectionType' field
+ */
+var CONNECTION_TYPE_VALUES = {
+  NODE_DRIVER: 'NODE_DRIVER',
+  STITCH_ON_PREM: 'STITCH_ON_PREM',
+  STITCH_ATLAS: 'STITCH_ATLAS'
+};
+
+/**
  * ## Driver Connection Options
  *
  * So really everything above is all about putting
@@ -893,6 +902,7 @@ Connection = AmpersandModel.extend({
       this.validate_x509(attrs);
       this.validate_ldap(attrs);
       this.validate_ssh_tunnel(attrs);
+      this.validate_stitch(attrs);
     } catch (err) {
       return err;
     }
@@ -1015,6 +1025,39 @@ Connection = AmpersandModel.extend({
     }
     if (!attrs.ssh_tunnel_port) {
       throw new TypeError('ssl_tunnel_port is required when ssh_tunnel is not NONE.');
+    }
+  },
+  validate_stitch: function(attrs) {
+    if (attrs.connectionType === CONNECTION_TYPE_VALUES.STITCH_ATLAS) {
+      if (!attrs.stitchClientAppId) {
+        throw new TypeError('stitchClientAppId is required when connectionType is STITCH_ATLAS.');
+      }
+    } else if (attrs.connectionType === CONNECTION_TYPE_VALUES.STITCH_ON_PREM) {
+      if (!attrs.stitchClientAppId) {
+        throw new TypeError('stitchClientAppId is required when connectionType is stitchOnPrem.');
+      }
+      if (!attrs.stitchBaseUrl) {
+        throw new TypeError('stitchBaseUrl is required when connectionType is stitchOnPrem.');
+      }
+      if (!attrs.stitchGroupId) {
+        throw new TypeError('stitchGroupId is required when connectionType is stitchOnPrem.');
+      }
+      if (!attrs.stitchServiceName) {
+        throw new TypeError('stitchServiceName is required when connectionType is stitchOnPrem.');
+      }
+    } else if (attrs.connectionType === CONNECTION_TYPE_VALUES.NODE_DRIVER) {
+      if (attrs.stitchClientAppId) {
+        throw new TypeError('stitchClientAppId should not be provided when connectionType is NODE_DRIVER.');
+      }
+      if (attrs.stitchBaseUrl) {
+        throw new TypeError('stitchBaseUrl should not be provided when connectionType is NODE_DRIVER.');
+      }
+      if (attrs.stitchGroupId) {
+        throw new TypeError('stitchGroupId should not be provided when connectionType is NODE_DRIVER.');
+      }
+      if (attrs.stitchServiceName) {
+        throw new TypeError('stitchServiceName should not be provided when connectionType is NODE_DRIVER.');
+      }
     }
   }
 });

--- a/lib/model.js
+++ b/lib/model.js
@@ -1034,16 +1034,16 @@ Connection = AmpersandModel.extend({
       }
     } else if (attrs.connectionType === CONNECTION_TYPE_VALUES.STITCH_ON_PREM) {
       if (!attrs.stitchClientAppId) {
-        throw new TypeError('stitchClientAppId is required when connectionType is stitchOnPrem.');
+        throw new TypeError('stitchClientAppId is required when connectionType is STITCH_ON_PREM.');
       }
       if (!attrs.stitchBaseUrl) {
-        throw new TypeError('stitchBaseUrl is required when connectionType is stitchOnPrem.');
+        throw new TypeError('stitchBaseUrl is required when connectionType is STITCH_ON_PREM.');
       }
       if (!attrs.stitchGroupId) {
-        throw new TypeError('stitchGroupId is required when connectionType is stitchOnPrem.');
+        throw new TypeError('stitchGroupId is required when connectionType is STITCH_ON_PREM.');
       }
       if (!attrs.stitchServiceName) {
-        throw new TypeError('stitchServiceName is required when connectionType is stitchOnPrem.');
+        throw new TypeError('stitchServiceName is required when connectionType is STITCH_ON_PREM.');
       }
     } else if (attrs.connectionType === CONNECTION_TYPE_VALUES.NODE_DRIVER) {
       if (attrs.stitchClientAppId) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -45,6 +45,13 @@ _.assign(props, {
     type: 'string',
     default: 'localhost'
   },
+  connectionType: {
+    type: 'string',
+    default: 'nodeDriver'
+  },
+  stitchServiceName: {
+    type: 'string'
+  },
   stitchClientAppId: {
     type: 'string'
   },

--- a/lib/model.js
+++ b/lib/model.js
@@ -26,6 +26,15 @@ function localPortGenerator() {
 }
 
 /**
+ * @constant {Object} - Allowed values for the 'connectionType' field
+ */
+var CONNECTION_TYPE_VALUES = {
+  NODE_DRIVER: 'NODE_DRIVER',
+  STITCH_ON_PREM: 'STITCH_ON_PREM',
+  STITCH_ATLAS: 'STITCH_ATLAS'
+};
+
+/**
  * # Top-Level
  */
 _.assign(props, {
@@ -47,7 +56,7 @@ _.assign(props, {
   },
   connectionType: {
     type: 'string',
-    default: 'nodeDriver'
+    default: CONNECTION_TYPE_VALUES.NODE_DRIVER
   },
   stitchServiceName: {
     type: 'string'
@@ -569,15 +578,6 @@ _.assign(props, {
     default: undefined
   }
 });
-
-/**
- * @constant {Object} - Allowed values for the 'connectionType' field
- */
-var CONNECTION_TYPE_VALUES = {
-  NODE_DRIVER: 'NODE_DRIVER',
-  STITCH_ON_PREM: 'STITCH_ON_PREM',
-  STITCH_ATLAS: 'STITCH_ATLAS'
-};
 
 /**
  * ## Driver Connection Options

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -875,4 +875,106 @@ describe('mongodb-connection-model', function() {
       });
     });
   });
+
+  describe('connectionType', function() {
+    context('when the connectionType is NODE_DRIVER', function() {
+      it('defaults  hostname to localhost', function() {
+        var c = new Connection({connectionType: 'NODE_DRIVER'});
+        assert.equal(c.hostname, 'localhost');
+      });
+      it('defaults port to 27017', function() {
+        var c = new Connection({connectionType: 'NODE_DRIVER'});
+        assert.equal(c.port, 27017);
+      });
+      it('does not allow stitchClientAppId', function() {
+        var c = new Connection({
+          connectionType: 'NODE_DRIVER',
+          stitchClientAppId: 'xkcd42'
+        });
+        assert.strictEqual(c.isValid(), false);
+      });
+      it('does not allow stitchBaseUrl', function() {
+        var c = new Connection({
+          connectionType: 'NODE_DRIVER',
+          stitchBaseUrl: 'http://localhost:9001/'
+        });
+        assert.strictEqual(c.isValid(), false);
+      });
+      it('does not allow stitchGroupId', function() {
+        var c = new Connection({
+          connectionType: 'NODE_DRIVER',
+          stitchGroupId: '23xkcd'
+        });
+        assert.strictEqual(c.isValid(), false);
+      });
+      it('does not allow stitchServiceName', function() {
+        var c = new Connection({
+          connectionType: 'NODE_DRIVER',
+          stitchServiceName: 'woof'
+        });
+        assert.strictEqual(c.isValid(), false);
+      });
+    });
+    context('when the connectionType is STITCH_ATLAS', function() {
+      it('requires a stitchClientAppId', function() {
+        var c = new Connection({connectionType: 'STITCH_ATLAS'});
+        assert.strictEqual(c.isValid(), false);
+      });
+      it('should be valid when stitchClientAppId is included', function() {
+        var c = new Connection({
+          connectionType: 'STITCH_ATLAS',
+          stitchClientAppId: 'xkcd42'
+        });
+        assert.strictEqual(c.isValid(), true);
+      });
+    });
+    context('when the connectionType is STITCH_ON_PREM', function() {
+      it('requires a stitchClientAppId', function() {
+        var c = new Connection({
+          connectionType: 'STITCH_ON_PREM',
+          stitchBaseUrl: 'http://localhost:9001/',
+          stitchGroupId: '23xkcd',
+          stitchServiceName: 'woof'
+        });
+        assert.strictEqual(c.isValid(), false);
+      });
+      it('requires a stitchBaseUrl', function() {
+        var c = new Connection({
+          connectionType: 'STITCH_ON_PREM',
+          stitchClientAppId: 'xkcd42',
+          stitchGroupId: '23xkcd',
+          stitchServiceName: 'woof'
+        });
+        assert.strictEqual(c.isValid(), false);
+      });
+      it('requires a stitchGroupId', function() {
+        var c = new Connection({
+          connectionType: 'STITCH_ON_PREM',
+          stitchClientAppId: 'xkcd42',
+          stitchBaseUrl: 'http://localhost:9001/',
+          stitchServiceName: 'woof'
+        });
+        assert.strictEqual(c.isValid(), false);
+      });
+      it('requires a stitchServiceName', function() {
+        var c = new Connection({
+          connectionType: 'STITCH_ON_PREM',
+          stitchClientAppId: 'xkcd42',
+          stitchBaseUrl: 'http://localhost:9001/',
+          stitchGroupId: '23xkcd'
+        });
+        assert.strictEqual(c.isValid(), false);
+      });
+      it('should be valid when all required fields are included', function() {
+        var c = new Connection({
+          connectionType: 'STITCH_ON_PREM',
+          stitchClientAppId: 'xkcd42',
+          stitchBaseUrl: 'http://localhost:9001/',
+          stitchGroupId: '23xkcd',
+          stitchServiceName: 'woof'
+        });
+        assert.strictEqual(c.isValid(), true);
+      });
+    });
+  });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -877,6 +877,10 @@ describe('mongodb-connection-model', function() {
   });
 
   describe('connectionType', function() {
+    it('defaults connectionType to NODE_DRIVER', function() {
+      var c = new Connection({});
+      assert.strictEqual(c.connectionType, 'NODE_DRIVER');
+    });
     context('when the connectionType is NODE_DRIVER', function() {
       it('defaults  hostname to localhost', function() {
         var c = new Connection({connectionType: 'NODE_DRIVER'});


### PR DESCRIPTION
[CHARTS-306](https://jira.mongodb.org/browse/CHARTS-306) adds additional stitch related options to the connection model to support both Atlas and on-prem stitch connections.

Included here are:
- connectionType
- stitchServiceName