### PR TITLE
COMPASS-3607 Consistency with compass connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Connection.from(
       connectionType: 'NODE_DRIVER',
       readPreference: 'primary',
       kerberosCanonicalizeHostname: false,
-      sslType: 'NONE',
+      sslMethod: 'NONE',
       sshTunnel: 'NONE',
       sshTunnelPort: 22
     }`
@@ -300,13 +300,13 @@ console.log(c.driverOptions)
 | Property | Type | Description | Default |
 | ----- | ---- | ---------- |  ----  |
 | `ssl` | Number/String | A boolean to enable or disables TLS/SSL for the connection | `undefined` |
-| `sslType` | String | The desired ssl strategy. Possible values: `NONE`, `SYSTEMCA`, `IFAVAILABLE`, `UNVALIDATED`, `SERVER`, `ALL` | `NONE` |
+| `sslMethod` | String | The desired ssl method. Possible values: `NONE`, `SYSTEMCA`, `IFAVAILABLE`, `UNVALIDATED`, `SERVER`, `ALL` | `NONE` |
 | `sslCA` | Buffer/String | Array of valid certificates | `undefined` |
 | `sslCert` | Buffer/String | The certificate | `undefined` |
 | `sslKey` | Buffer/String | The certificate private key | `undefined` |
 | `sslPass` | Buffer/String | The certificate password | `undefined` |
 
-Description of `sslType` values:
+Description of `sslMethod` values:
 
 - `SYSTEMCA` - SSL required, validate using System CA, with host verification.
 - `IFAVAILABLE` - The driver should try SSL first, fall back to no SSL if unavailable, and use the system's Certificate Authority.

--- a/constants/ssl-method-values.js
+++ b/constants/ssl-method-values.js
@@ -1,4 +1,4 @@
-// Allowed values for the `sslType` field
+// Allowed values for the `sslMethod` field
 module.exports = [
   /**
    * Do not use SSL for anything.

--- a/lib/extended-model.js
+++ b/lib/extended-model.js
@@ -16,7 +16,7 @@ try {
 /**
  * Configuration for connecting to a MongoDB Deployment.
  */
-module.exports = Connection.extend(storageMixin, {
+const ExtendedConnection = Connection.extend(storageMixin, {
   idAttribute: '_id',
   namespace: 'Connections',
   storage: {
@@ -33,7 +33,8 @@ module.exports = Connection.extend(storageMixin, {
     isFavorite: { type: 'boolean', default: false },
     name: { type: 'string', default: 'Local' },
     ns: { type: 'string', default: undefined },
-    isSrvRecord: { type: 'boolean', default: false }
+    isSrvRecord: { type: 'boolean', default: false },
+    appname: { type: 'string', default: undefined }
   },
   session: { selected: { type: 'boolean', default: false } },
   derived: {
@@ -63,3 +64,20 @@ module.exports = Connection.extend(storageMixin, {
     return Connection.prototype.serialize.call(this, { all: true });
   }
 });
+
+/**
+ * Create a connection from a URI. This needs to ensure we create our subclass
+ * or we won't have the storage mixin available.
+ *
+ * @param {String} url - The mongodb url to create from.
+ * @param {Function} callback - The callback function.
+ */
+ExtendedConnection.from = (url, callback) => Connection.from(url, (error, c) => {
+  if (error) {
+    return callback(error);
+  }
+
+  callback(null, new ExtendedConnection(c.getAttributes({ props: true })));
+});
+
+module.exports = ExtendedConnection;

--- a/lib/model.js
+++ b/lib/model.js
@@ -21,7 +21,7 @@ const AUTH_MECHANISM_TO_AUTH_STRATEGY = require('../constants/auth-mechanism-to-
 const AUTHENICATION_TO_AUTH_MECHANISM = require('../constants/auth-strategy-to-auth-mechanism');
 const AUTH_STRATEGY_VALUES = require('../constants/auth-strategy-values');
 const AUTH_STRATEGY_TO_FIELD_NAMES = require('../constants/auth-strategy-to-field-names');
-const SSL_TYPE_VALUES = require('../constants/ssl-type-values');
+const SSL_METHOD_VALUES = require('../constants/ssl-method-values');
 const SSH_TUNNEL_VALUES = require('../constants/ssh-tunnel-values');
 const READ_PREFERENCE_VALUES = [
   ReadPreference.PRIMARY,
@@ -298,7 +298,7 @@ assign(props, {
  */
 assign(props, {
   ssl: { type: 'any', default: undefined },
-  sslType: { type: 'string', values: SSL_TYPE_VALUES, default: SSL_DEFAULT },
+  sslMethod: { type: 'string', values: SSL_METHOD_VALUES, default: SSL_DEFAULT },
   /**
    * Array of valid certificates either as Buffers or Strings
    * (needs to have a mongod server with ssl support, 2.4 or higher).
@@ -478,11 +478,11 @@ assign(derived, {
 
       if (this.ssl) {
         req.query.ssl = this.ssl;
-      } else if (includes(['UNVALIDATED', 'SYSTEMCA', 'SERVER', 'ALL'], this.sslType)) {
+      } else if (includes(['UNVALIDATED', 'SYSTEMCA', 'SERVER', 'ALL'], this.sslMethod)) {
         req.query.ssl = 'true';
-      } else if (this.sslType === 'IFAVAILABLE') {
+      } else if (this.sslMethod === 'IFAVAILABLE') {
         req.query.ssl = 'prefer';
-      } else if (this.sslType === 'NONE') {
+      } else if (this.sslMethod === 'NONE') {
         req.query.ssl = 'false';
       }
 
@@ -558,9 +558,9 @@ assign(derived, {
     fn() {
       const opts = clone(DRIVER_OPTIONS_DEFAULT, true);
 
-      if (this.sslType === 'SERVER') {
+      if (this.sslMethod === 'SERVER') {
         assign(opts, { sslValidate: true, sslCA: this.sslCA });
-      } else if (this.sslType === 'ALL') {
+      } else if (this.sslMethod === 'ALL') {
         assign(opts, {
           sslValidate: true,
           sslCA: this.sslCA,
@@ -576,11 +576,11 @@ assign(derived, {
           opts.checkServerIdentity = false;
           opts.sslValidate = false;
         }
-      } else if (this.sslType === 'UNVALIDATED') {
+      } else if (this.sslMethod === 'UNVALIDATED') {
         assign(opts, { checkServerIdentity: false, sslValidate: false });
-      } else if (this.sslType === 'SYSTEMCA') {
+      } else if (this.sslMethod === 'SYSTEMCA') {
         assign(opts, { checkServerIdentity: true, sslValidate: true });
-      } else if (this.sslType === 'IFAVAILABLE') {
+      } else if (this.sslMethod === 'IFAVAILABLE') {
         assign(opts, { checkServerIdentity: false, sslValidate: true });
       }
 
@@ -744,15 +744,15 @@ Connection = AmpersandModel.extend({
    */
   validateSsl(attrs) {
     if (
-      !attrs.sslType ||
-      includes(['NONE', 'UNVALIDATED', 'IFAVAILABLE', 'SYSTEMCA'], attrs.sslType)
+      !attrs.sslMethod ||
+      includes(['NONE', 'UNVALIDATED', 'IFAVAILABLE', 'SYSTEMCA'], attrs.sslMethod)
     ) {
       return;
     }
 
-    if (attrs.sslType === 'SERVER' && !attrs.sslCA) {
+    if (attrs.sslMethod === 'SERVER' && !attrs.sslCA) {
       throw new TypeError('sslCA is required when ssl is SERVER.');
-    } else if (attrs.sslType === 'ALL') {
+    } else if (attrs.sslMethod === 'ALL') {
       if (!attrs.sslCA) {
         throw new TypeError('sslCA is required when ssl is ALL.');
       }
@@ -1028,7 +1028,7 @@ Connection._improveAtlasDefaults = (url, mongodbPassword, ns) => {
   const atlasConnectionAttrs = {};
 
   if (Connection.isAtlas(url)) {
-    atlasConnectionAttrs.sslType = 'SYSTEMCA';
+    atlasConnectionAttrs.sslMethod = 'SYSTEMCA';
 
     if (mongodbPassword.match(/^.?PASSWORD.?$/i)) {
       atlasConnectionAttrs.mongodbPassword = '';
@@ -1057,7 +1057,7 @@ Connection.isURI = (str) => (str.startsWith('mongodb://')) || (str.startsWith('m
 
 Connection.AUTH_STRATEGY_VALUES = AUTH_STRATEGY_VALUES;
 Connection.AUTH_STRATEGY_DEFAULT = AUTH_STRATEGY_DEFAULT;
-Connection.SSL_TYPE_VALUES = SSL_TYPE_VALUES;
+Connection.SSL_METHOD_VALUES = SSL_METHOD_VALUES;
 Connection.SSL_DEFAULT = SSL_DEFAULT;
 Connection.SSH_TUNNEL_VALUES = SSH_TUNNEL_VALUES;
 Connection.SSH_TUNNEL_DEFAULT = SSH_TUNNEL_DEFAULT;

--- a/test/build-uri.test.js
+++ b/test/build-uri.test.js
@@ -38,14 +38,14 @@ describe('connection model builder', () => {
       });
     });
 
-    it('when the connection is a srv record and sslType is NONE', () => {
-      const c = new Connection({ isSrvRecord: true, sslType: 'NONE' });
+    it('when the connection is a srv record and sslMethod is NONE', () => {
+      const c = new Connection({ isSrvRecord: true, sslMethod: 'NONE' });
 
       expect(c.driverUrl).to.be.equal('mongodb+srv://localhost/?readPreference=primary&ssl=false');
     });
 
-    it('when sslType is NONE', (done) => {
-      const c = new Connection({ sslType: 'NONE' });
+    it('when sslMethod is NONE', (done) => {
+      const c = new Connection({ sslMethod: 'NONE' });
 
       expect(c.driverUrl).to.be.equal('mongodb://localhost:27017/?readPreference=primary&ssl=false');
 
@@ -55,8 +55,8 @@ describe('connection model builder', () => {
       });
     });
 
-    it('when sslType is UNVALIDATED', (done) => {
-      const c = new Connection({ sslType: 'UNVALIDATED' });
+    it('when sslMethod is UNVALIDATED', (done) => {
+      const c = new Connection({ sslMethod: 'UNVALIDATED' });
       const options = Object.assign(
         {},
         Connection.DRIVER_OPTIONS_DEFAULT,
@@ -77,8 +77,8 @@ describe('connection model builder', () => {
       });
     });
 
-    it('when sslType is SYSTEMCA', (done) => {
-      const c = new Connection({ sslType: 'SYSTEMCA' });
+    it('when sslMethod is SYSTEMCA', (done) => {
+      const c = new Connection({ sslMethod: 'SYSTEMCA' });
       const options = Object.assign(
         {},
         Connection.DRIVER_OPTIONS_DEFAULT,
@@ -99,8 +99,8 @@ describe('connection model builder', () => {
       });
     });
 
-    it('when sslType is IFAVAILABLE', (done) => {
-      const c = new Connection({ sslType: 'IFAVAILABLE' });
+    it('when sslMethod is IFAVAILABLE', (done) => {
+      const c = new Connection({ sslMethod: 'IFAVAILABLE' });
       const options = Object.assign(
         {},
         Connection.DRIVER_OPTIONS_DEFAULT,
@@ -121,8 +121,8 @@ describe('connection model builder', () => {
       });
     });
 
-    it('when sslType is SERVER', (done) => {
-      const c = new Connection({ sslType: 'SERVER', sslCA: fixture.ssl.ca });
+    it('when sslMethod is SERVER', (done) => {
+      const c = new Connection({ sslMethod: 'SERVER', sslCA: fixture.ssl.ca });
       const options = Object.assign(
         {},
         Connection.DRIVER_OPTIONS_DEFAULT,
@@ -143,9 +143,9 @@ describe('connection model builder', () => {
       });
     });
 
-    it('when sslType is ALL and using X509 auth', (done) => {
+    it('when sslMethod is ALL and using X509 auth', (done) => {
       const c = new Connection({
-        sslType: 'ALL',
+        sslMethod: 'ALL',
         sslCA: fixture.ssl.ca,
         sslCert: fixture.ssl.server,
         sslKey: fixture.ssl.server,
@@ -175,9 +175,9 @@ describe('connection model builder', () => {
       });
     });
 
-    it('when sslType is ALL and passwordless private keys', (done) => {
+    it('when sslMethod is ALL and passwordless private keys', (done) => {
       const c = new Connection({
-        sslType: 'ALL',
+        sslMethod: 'ALL',
         sslCA: fixture.ssl.ca,
         sslCert: fixture.ssl.server,
         sslKey: fixture.ssl.server
@@ -217,9 +217,9 @@ describe('connection model builder', () => {
       });
     });
 
-    it('when sslType is ALL and password protected private keys', (done) => {
+    it('when sslMethod is ALL and password protected private keys', (done) => {
       const c = new Connection({
-        sslType: 'ALL',
+        sslMethod: 'ALL',
         sslCA: fixture.ssl.ca,
         sslCert: fixture.ssl.server,
         sslKey: fixture.ssl.server,
@@ -724,9 +724,9 @@ describe('connection model builder', () => {
         expect(c.sshTunnelBindToLocalPort).to.exist;
       });
 
-      it('when sslType ia ALL should load all of the files from the filesystem', (done) => {
+      it('when sslMethod ia ALL should load all of the files from the filesystem', (done) => {
         const c = new Connection({
-          sslType: 'ALL',
+          sslMethod: 'ALL',
           sslCA: [fixture.ssl.ca],
           sslCert: fixture.ssl.server,
           sslKey: fixture.ssl.server

--- a/test/parse-uri-common-targets.test.js
+++ b/test/parse-uri-common-targets.test.js
@@ -19,7 +19,7 @@ describe('connection model parser should parse URI strings for common connection
         expect(error).to.not.exist;
         expect(result.replicaSet).to.be.equal('a-compass-atlas-test-shard-0');
         expect(result.readPreference).to.be.equal('secondary');
-        expect(result.sslType).to.be.equal('SYSTEMCA');
+        expect(result.sslMethod).to.be.equal('SYSTEMCA');
         expect(result.mongodbPassword).to.be.equal('');
         expect(result.ns).to.be.equal('admin');
         expect(result.driverUrl).to.include('authSource=admin');
@@ -41,7 +41,7 @@ describe('connection model parser should parse URI strings for common connection
 
       Connection.from(modifiedAtlasConnection, (error, result) => {
         expect(error).to.not.exist;
-        expect(result.sslType).to.be.equal('SYSTEMCA');
+        expect(result.sslMethod).to.be.equal('SYSTEMCA');
         expect(result.mongodbPassword).to.be.equal(userPass);
         done();
       });
@@ -55,7 +55,7 @@ describe('connection model parser should parse URI strings for common connection
 
       Connection.from(modifiedAtlasConnection, (error, result) => {
         expect(error).to.not.exist;
-        expect(result.sslType).to.be.equal('NONE');
+        expect(result.sslMethod).to.be.equal('NONE');
         done();
       });
     });
@@ -65,7 +65,7 @@ describe('connection model parser should parse URI strings for common connection
 
       Connection.from(modifiedAtlasConnection, (error, result) => {
         expect(error).to.not.exist;
-        expect(result.sslType).to.be.equal('SYSTEMCA');
+        expect(result.sslMethod).to.be.equal('SYSTEMCA');
         done();
       });
     });


### PR DESCRIPTION
- Variable name change to be consistent with compass connection plugin (sslType was replaced with sslMethod)
- Extended model was updated to ensure we create our a subclass or we won't have the storage mixin available