### PR TITLE
COMPASS-3589 testing srv

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,14 +337,14 @@ const options = {
   sshTunnelIdentityFile: ['/Users/albert/.ssh/my-key-aws-pair.pem']
 };
 
-connect(options, (connectError, db) => {
-  if (connectError) {
-    return console.log(connectError);
+connect(options, (connectionError, client) => {
+  if (connectionError) {
+    return console.log(connectionError);
   }
 
-  db.db('mongodb').collection('fanclub').count((error, count) => {
-    console.log('counted:', error, count);
-    db.close();
+  client.db('mongodb').collection('fanclub').count((countingError, count) => {
+    console.log('counted:', countingError, count);
+    client.close();
   });
 });
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -3212,6 +3212,16 @@
         "trim-repeated": "^1.0.0"
       }
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      }
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -5667,6 +5677,12 @@
         "trim-newlines": "^1.0.0"
       }
     },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
     "merge2": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
@@ -5880,6 +5896,12 @@
         "ast-module-types": "^2.4.0",
         "node-source-walk": "^4.0.0"
       }
+    },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
     },
     "mongodb": {
       "version": "3.2.2",
@@ -7820,6 +7842,28 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "dev": true
+    },
+    "proxyquire": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
+      "integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
+      "dev": true,
+      "requires": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.0",
+        "resolve": "~1.8.1"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+          "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.5"
+          }
+        }
+      }
     },
     "ps-node": {
       "version": "0.1.6",

--- a/package.json
+++ b/package.json
@@ -52,13 +52,14 @@
     "eslint-config-mongodb-js": "^5.0.3",
     "lodash.foreach": "^4.5.0",
     "mocha": "^3.2.0",
-    "mock-require": "^2.0.1",
+    "mock-require": "^2.0.2",
     "mongodb-connection-fixture": "^0.0.14",
     "mongodb-data-service": "^14.0.5",
     "mongodb-js-fmt": "^1.0.0",
     "mongodb-js-precommit": "^2.0.0",
     "mongodb-runner": "^4.6.0",
     "pre-commit": "^1.1.2",
+    "proxyquire": "^2.1.0",
     "sinon": "^1.17.7",
     "uuid": "^3.3.2"
   }

--- a/test/parse-uri-components.test.js
+++ b/test/parse-uri-components.test.js
@@ -1,17 +1,58 @@
 const Connection = require('../');
 const chai = require('chai');
 const expect = chai.expect;
+const proxyquire = require('proxyquire');
+
+let stubHostname = '';
+const stubs = {
+  'dns': {
+    resolveSrv: (uri, callback) => {
+      callback(null, [{ name: stubHostname }]);
+    },
+    resolveTxt: (addresses, callback) => {
+      callback(null);
+    },
+    '@global': true
+  }
+};
+
+const stubedConnection = proxyquire('../', stubs);
 
 chai.use(require('chai-subset'));
 
 describe('connection model partser should parse URI components such as', () => {
   describe('prefix', () => {
-    it('should not set isSrvRecord', (done) => {
+    it('should set isSrvRecord to false', (done) => {
       Connection.from(
         'mongodb://mongodb1.example.com:27317,mongodb2.example.com:27017/?replicaSet=mySet&authSource=authDB',
         (error, result) => {
           expect(error).to.not.exist;
           expect(result.isSrvRecord).to.be.equal(false);
+          done();
+        }
+      );
+    });
+
+    it('should set isSrvRecord to true', (done) => {
+      stubHostname = 'server.example.com';
+      stubedConnection.from(
+        `mongodb+srv://${stubHostname}/?connectTimeoutMS=300000&authSource=aDifferentAuthDB`,
+        (error, result) => {
+          expect(error).to.not.exist;
+          expect(result.isSrvRecord).to.be.equal(true);
+          done();
+        }
+      );
+    });
+
+    it('should set only one hostname without decorating it with the replica set info', (done) => {
+      stubHostname = 'test.mongodb.net';
+      stubedConnection.from(
+        `mongodb+srv://admin:qwerty@${stubHostname}/admin`,
+        (error, result) => {
+          expect(error).to.not.exist;
+          expect(result.isSrvRecord).to.be.equal(true);
+          expect(result.hostname).to.be.equal('test.mongodb.net');
           done();
         }
       );

--- a/test/parse-uri-components.test.js
+++ b/test/parse-uri-components.test.js
@@ -3,19 +3,20 @@ const chai = require('chai');
 const expect = chai.expect;
 const proxyquire = require('proxyquire');
 
+// To test SRV connection strings we need to use `proxyquire`.
+// Because driver parser resolves the SRV record and uses the result as the list
+// of hosts to connect to. Since tests don't have real data that can be resolved
+// the driver check would always fail.
+// To make tests work we need to mock dns methods.
 let stubHostname = '';
 const stubs = {
   'dns': {
-    resolveSrv: (uri, callback) => {
-      callback(null, [{ name: stubHostname }]);
-    },
-    resolveTxt: (addresses, callback) => {
-      callback(null);
-    },
+    resolveSrv: (uri, callback) => callback(null, [{ name: stubHostname }]),
+    resolveTxt: (addresses, callback) => callback(null),
+    // To get access to the deeply nested dependencies we need to move them to the global level
     '@global': true
   }
 };
-
 const stubedConnection = proxyquire('../', stubs);
 
 chai.use(require('chai-subset'));


### PR DESCRIPTION
Ability to test SRV connection strings.

Driver parser resolves the SRV record and uses the result as the list of hosts to connect to. Since tests don't have real data that can be resolved the driver check always fails. To make tests work we need to mock `dns.resolveSrv()` and `dns.resolveTxt()` methods. To do so the `proxyquire` module was added to the project. It has an ability to replace a particular module through making this module kind of global `'@global': true`. By doing this a module can be overwritten in the test even if it is deeply nested in node modules dependencies.

More info about `globally override require`:
https://github.com/thlorenz/proxyquire#globally-override-require