### PR TITLE
fix: set proper app name

### DIFF
--- a/lib/connection-collection.js
+++ b/lib/connection-collection.js
@@ -4,12 +4,12 @@ const storageMixin = require('storage-mixin');
 const each = require('lodash.foreach');
 const raf = require('raf');
 
-let appname;
+let appName;
 
 try {
   const electron = require('electron');
 
-  appname = electron.remote ? electron.remote.app : undefined;
+  appName = electron.remote ? electron.remote.app.getName() : undefined;
 } catch (e) {
   /* eslint no-console: 0 */
   console.log('Could not load electron', e.message);
@@ -18,7 +18,7 @@ try {
 module.exports = Collection.extend(storageMixin, {
   model: Connection,
   namespace: 'Connections',
-  storage: { backend: 'splice', appname },
+  storage: { backend: 'splice', appName },
   comparator: (a, b) => {
     if (a.isFavorite === b.isFavorite) {
       return a.lastUsed - b.lastUsed;

--- a/lib/connection-collection.js
+++ b/lib/connection-collection.js
@@ -4,6 +4,10 @@ const storageMixin = require('storage-mixin');
 const each = require('lodash.foreach');
 const raf = require('raf');
 
+/**
+ * The name of a remote electon application that
+ * uses `connection-model` as a dependency.
+ */
 let appName;
 
 try {

--- a/lib/extended-model.js
+++ b/lib/extended-model.js
@@ -2,6 +2,10 @@ const Connection = require('./model');
 const storageMixin = require('storage-mixin');
 const uuid = require('uuid');
 
+/**
+ * The name of a remote electon application that
+ * uses `connection-model` as a dependency.
+ */
 let appName;
 
 try {
@@ -21,7 +25,7 @@ const ExtendedConnection = Connection.extend(storageMixin, {
   namespace: 'Connections',
   storage: {
     backend: 'splice',
-    appName,
+    appName, // Not to be confused with `props.appname` that is being sent to driver
     secureCondition: (val, key) => key.match(/(password|passphrase)/i)
   },
   props: {

--- a/lib/extended-model.js
+++ b/lib/extended-model.js
@@ -2,12 +2,12 @@ const Connection = require('./model');
 const storageMixin = require('storage-mixin');
 const uuid = require('uuid');
 
-let appname;
+let appName;
 
 try {
   const electron = require('electron');
 
-  appname = electron.remote ? electron.remote.app : undefined;
+  appName = electron.remote ? electron.remote.app.getName() : undefined;
 } catch (e) {
   /* eslint no-console: 0 */
   console.log('Could not load electron', e.message);
@@ -21,7 +21,7 @@ const ExtendedConnection = Connection.extend(storageMixin, {
   namespace: 'Connections',
   storage: {
     backend: 'splice',
-    appname,
+    appName,
     secureCondition: (val, key) => key.match(/(password|passphrase)/i)
   },
   props: {
@@ -71,6 +71,8 @@ const ExtendedConnection = Connection.extend(storageMixin, {
  *
  * @param {String} url - The mongodb url to create from.
  * @param {Function} callback - The callback function.
+ *
+ * @returns {Function} callback
  */
 ExtendedConnection.from = (url, callback) => Connection.from(url, (error, c) => {
   if (error) {

--- a/test/ssh-tunnel.test.js
+++ b/test/ssh-tunnel.test.js
@@ -298,7 +298,7 @@ describe('sshTunnel', function() {
         assert(c.isValid());
       });
 
-      describe('ssh_tunnel_options', () => {
+      describe('sshTunnelOptions', () => {
         const options = c.sshTunnelOptions;
 
         it('maps sshTunnelUsername -> username', () => {


### PR DESCRIPTION
- Update accessing app name from remote electron app
- Update the property name. Replace wrong `appname` with proper `appName`

Part of: https://jira.mongodb.org/browse/COMPASS-3821