### PR TITLE
COMPASS-723 Increase ssh tunnel connection timeouts

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -625,9 +625,9 @@ assign(derived, {
       }
 
       const opts = {
-        readyTimeout: 5000,
-        forwardTimeout: 5000,
-        keepaliveInterval: 5000,
+        readyTimeout: 20000,
+        forwardTimeout: 20000,
+        keepaliveInterval: 20000,
         srcAddr: '127.0.0.1', // OS should figure out an ephemeral srcPort
         dstPort: this.port,
         dstAddr: this.hostname,


### PR DESCRIPTION
**Description**

Increase ssh tunnel connection timeouts from 5 seconds to 20 seconds	

**Checklist**

- [x] existing tests pass
- [ ] new tests and/or benchmarks are included
- [ ] documentation is changed or added

**Types of changes**

- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)