### PR TITLE
COMPASS-3887 Make sure server appname is properly set

### DIFF
--- a/lib/extended-model.js
+++ b/lib/extended-model.js
@@ -6,12 +6,12 @@ const uuid = require('uuid');
  * The name of a remote electon application that
  * uses `connection-model` as a dependency.
  */
-let appName;
+let appNameElectron;
 let appPath;
 
 try {
   const electron = require('electron');
-  appName = electron.remote ? electron.remote.app.getName() : undefined;
+  appNameElectron = electron.remote ? electron.remote.app.getName() : undefined;
   appPath = electron.remote ? electron.remote.app.getPath('userData') : undefined;
 } catch (e) {
   /* eslint no-console: 0 */
@@ -28,7 +28,7 @@ const ExtendedConnection = Connection.extend(storageMixin, {
     backend: 'splice-disk-ipc',
     namespace: 'Connections',
     basepath: appPath,
-    appName: appName, // Not to be confused with `props.appname` that is being sent to driver
+    appName: appNameElectron, // Not to be confused with `props.appname` that is being sent to driver
     secureCondition: (val, key) => key.match(/(password|passphrase)/i)
   },
   props: {
@@ -41,7 +41,7 @@ const ExtendedConnection = Connection.extend(storageMixin, {
     name: { type: 'string', default: 'Local' },
     ns: { type: 'string', default: undefined },
     isSrvRecord: { type: 'boolean', default: false },
-    appname: { type: 'string', default: undefined }
+    appname: { type: 'string', default: appNameElectron } // Is being sent to driver
   },
   session: { selected: { type: 'boolean', default: false } },
   derived: {


### PR DESCRIPTION
**Description**

Server log should include application metadata:

```
2019-09-10T10:23:11.168+0200 I NETWORK  [conn21] received client metadata from
127.0.0.1:57822 conn: {
  driver: { name: "nodejs-core", version: "3.2.7" },
  os: { type: "Darwin", name: "darwin", architecture: "x64", version: "18.6.0" },
  platform: "Node.js v10.2.0, LE",
  application: { name: "MongoDB Compass Dev" }
}
```

**Checklist**

- [x] existing tests pass
- [ ] new tests and/or benchmarks are included
- [ ] documentation is changed or added

**Types of changes**

- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)