### PR TITLE
COMPASS-3893 Connect screen issues

### DIFF
--- a/lib/extended-model.js
+++ b/lib/extended-model.js
@@ -6,12 +6,12 @@ const uuid = require('uuid');
  * The name of a remote electon application that
  * uses `connection-model` as a dependency.
  */
-let appNameElectron;
+let appName;
 let appPath;
 
 try {
   const electron = require('electron');
-  appNameElectron = electron.remote ? electron.remote.app.getName() : undefined;
+  appName = electron.remote ? electron.remote.app.getName() : undefined;
   appPath = electron.remote ? electron.remote.app.getPath('userData') : undefined;
 } catch (e) {
   /* eslint no-console: 0 */
@@ -28,7 +28,7 @@ const ExtendedConnection = Connection.extend(storageMixin, {
     backend: 'splice-disk-ipc',
     namespace: 'Connections',
     basepath: appPath,
-    appName: appNameElectron, // Not to be confused with `props.appname` that is being sent to driver
+    appName, // Not to be confused with `props.appname` that is being sent to driver
     secureCondition: (val, key) => key.match(/(password|passphrase)/i)
   },
   props: {
@@ -41,7 +41,7 @@ const ExtendedConnection = Connection.extend(storageMixin, {
     name: { type: 'string', default: 'Local' },
     ns: { type: 'string', default: undefined },
     isSrvRecord: { type: 'boolean', default: false },
-    appname: { type: 'string', default: appNameElectron } // Is being sent to driver
+    appname: { type: 'string', default: undefined } // Is being sent to driver
   },
   session: { selected: { type: 'boolean', default: false } },
   derived: {


### PR DESCRIPTION
## Description

Remove default `appname` value to not show this attribute in URI and prevent users from changing it manually.  Now, `appname` is being set in `compass-connect` before establishing a connection.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)