### PR TITLE
fix: allow to unser properties

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -138,7 +138,7 @@ const CONNECTION_STRING_OPTIONS = {
   retryWrites: { type: 'boolean', default: undefined },
   uuidRepresentation: {
     type: 'string',
-    values: ['standard', 'csharpLegacy', 'javaLegacy', 'pythonLegacy'],
+    values: [undefined, 'standard', 'csharpLegacy', 'javaLegacy', 'pythonLegacy'],
     default: undefined
   }
 };
@@ -459,7 +459,7 @@ assign(derived, {
 
       Object.keys(CONNECTION_STRING_OPTIONS).forEach((item) => {
         if (typeof this[item] !== 'undefined' && !req.query[item]) {
-          if (item === 'compression') {
+          if (item === 'compression' && this.compression) {
             if (this.compression.compressors) {
               req.query.compressors = this.compression.compressors.join(',');
             }


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Update a connection model to be able to unset all properties. Only `uuidRepresentation` and `compression` were throwing the error because ampersand js didn't allow to use `undefined` as value of `uuidRepresentation`. And failed to parse `this.compression.compressors` when `compression` had `undefined` value.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
