### PR TITLE
fix: COMPASS-4135: Make auth prop session only

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -74,7 +74,6 @@ assign(props, {
    */
   ns: { type: 'string', default: undefined },
   isSrvRecord: { type: 'boolean', default: false },
-  
   hostname: { type: 'string', default: 'localhost' },
   port: { type: 'port', default: 27017 },
   hosts: {

--- a/lib/model.js
+++ b/lib/model.js
@@ -74,7 +74,7 @@ assign(props, {
    */
   ns: { type: 'string', default: undefined },
   isSrvRecord: { type: 'boolean', default: false },
-  auth: { type: 'object', default: undefined },
+  
   hostname: { type: 'string', default: 'localhost' },
   port: { type: 'port', default: 27017 },
   hosts: {
@@ -715,6 +715,9 @@ Connection = AmpersandModel.extend({
   idAttribute: 'instanceId',
   props,
   derived,
+  session: {
+    auth: { type: 'object', default: undefined },
+  },
   dataTypes,
   initialize(attrs) {
     if (attrs) {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1,7 +1,42 @@
+/* eslint-disable guard-for-in */
 const assert = require('assert');
 const Connection = require('../');
+const _ = require('lodash');
+function flattenObject(o, prefix = '', result = {}, keepNull = true) {
+  if (_.isString(o) || _.isNumber(o) || _.isBoolean(o) || (keepNull && _.isNull(o))) {
+    result[prefix] = o;
+    return result;
+  }
+
+  if (_.isArray(o) || _.isPlainObject(o)) {
+    for (let i in o) {
+      let pref = prefix;
+      if (_.isArray(o)) {
+        pref = pref + `[${i}]`;
+      } else {
+        if (_.isEmpty(prefix)) {
+          pref = i;
+        } else {
+          pref = prefix + '.' + i;
+        }
+      }
+      flattenObject(o[i], pref, result, keepNull);
+    }
+    return result;
+  }
+  return result;
+}
 
 describe('Connection', () => {
+  describe('serialize', () => {
+    it('should not contain any sensitive data', () => {
+      const conn = new Connection({ mongodb_password: 'mypassword' });
+      const result = flattenObject(conn.serialize());
+      for (let key in result) {
+        assert.notEqual(('' + result[key]).includes('mypassword'), true);
+      }
+    });
+  });
   describe('#parse', () => {
     context('when the attributes have legacy passwords', () => {
       context('when the attributes have no new passwords', () => {


### PR DESCRIPTION
## Description

[`session` props](https://ampersandjs.com/docs/#ampersand-state-session) are not serialized so marking `auth` as session avoids risk of ending up on disk. COMPASS-4135 should also contain a migration for re-serializing all connections on disk.

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context

- [x] Bugfix

## Types of changes

- [x] Patch (non-breaking change which fixes an issue)
