### PR TITLE
COMPASS-4057: Don't replace host/port on SSH tunnel connect

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -586,12 +586,6 @@ assign(derived, {
 
       const reqClone = clone(req);
 
-      if (this.sshTunnel !== 'NONE') {
-        // Populate the SSH Tunnel options correctly
-        reqClone.hostname = this.sshTunnelOptions.localAddr;
-        reqClone.port = this.sshTunnelOptions.localPort;
-      }
-
       return toURL(reqClone);
     }
   },

--- a/test/build-uri.test.js
+++ b/test/build-uri.test.js
@@ -839,7 +839,7 @@ describe('Connection model builder', () => {
         c.sshTunnelPassword = 'pass';
 
         expect(c.driverUrl).to.not.be.equal('');
-        expect(c.sshTunnelBindToLocalPort).to.exist;
+        expect(c.sshTunnelBindToLocalPort).to.not.exist;
       });
 
       it('should load all of the files from the filesystem if sslMethod ia ALL', (done) => {

--- a/test/connect.test.js
+++ b/test/connect.test.js
@@ -62,7 +62,7 @@ describe('connection model connector', () => {
       it('should close ssh tunnel if the connection fails', done => {
         const model = new MockConnection({
           hostname: 'localhost',
-          port: '27017',
+          port: '27020',
           sshTunnel: 'USER_PASSWORD',
           sshTunnelHostname: 'my.ssh-server.com',
           sshTunnelPassword: 'password',
@@ -73,6 +73,7 @@ describe('connection model connector', () => {
         assert(model.isValid());
         mockConnect(model, setupListeners, err => {
           // must throw error here, because the connection details are invalid
+          console.log(err);
           assert.ok(err);
           assert.ok(/ECONNREFUSED/.test(err.message));
           // assert that tunnel.close() was called once

--- a/test/connect.test.js
+++ b/test/connect.test.js
@@ -73,7 +73,6 @@ describe('connection model connector', () => {
         assert(model.isValid());
         mockConnect(model, setupListeners, err => {
           // must throw error here, because the connection details are invalid
-          console.log(err);
           assert.ok(err);
           assert.ok(/ECONNREFUSED/.test(err.message));
           // assert that tunnel.close() was called once


### PR DESCRIPTION
COMPASS-4057

## Description
The generated driver URI cannot connect via a SSH tunnel because the current behaviour replaces the host and port of the cluster with the actual SSH tunnel details.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
