### PR TITLE
COMPASS-4278: Read preference tag group to url fix

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -552,11 +552,15 @@ const prepareRequest = (model) => {
         }
       } else if (item === 'readPreferenceTags') {
         if (model.readPreferenceTags) {
-          req.query.readPreferenceTags = Object.keys(
+          req.query.readPreferenceTags = Object.values(
             model.readPreferenceTags
-          )
-            .map(tag => `${tag}:${model.readPreferenceTags[tag]}`)
-            .join(',');
+          ).map(
+            tagGroup => Object.keys(
+              tagGroup
+            )
+              .map(tag => `${tag}:${tagGroup[tag]}`)
+              .join(',')
+          );
         }
       } else if (model[item] !== '') {
         req.query[item] = model[item];

--- a/test/parse-and-build-uri.js
+++ b/test/parse-and-build-uri.js
@@ -72,7 +72,14 @@ const tests = [
       'with readPreference, maxStalenessSeconds and readPreferenceTags',
     connectionString:
       'mongodb://mongos1.example.com:27017,mongos2.example.com:27017/?' +
-      'readPreference=secondary&maxStalenessSeconds=120&readPreferenceTags=0%3A%5Bobject%20Object%5D&ssl=false'
+      'readPreference=secondary&maxStalenessSeconds=120&readPreferenceTags=dc%3Any%2Crack%3A1&ssl=false'
+  },
+  {
+    description:
+      'with multiple readPreferenceTags',
+    connectionString:
+      'mongodb://mongos1.example.com:27017,mongos2.example.com:27017/?' +
+      'readPreference=primary&readPreferenceTags=dc%3Any%2Crack%3A1&readPreferenceTags=region%3Anorth%2Cdatacenter%3AA&ssl=false'
   },
   {
     description: 'with authSource and authMechanism',


### PR DESCRIPTION
https://jira.mongodb.org/browse/COMPASS-4278

This PR changes how we build the query string's `readPreferenceTags` to ensure we keep tag groups intact and don't lose tag data. 
https://docs.mongodb.com/manual/core/read-preference-tags/

Tested locally with replica set - previous compass wouldn't connect, now it can connect. Tested with multiple read preference tag sets.

Testing steps:
```
1. Start up local replica set:
mongod --replSet rs1 --port 27017 --dbpath=/users/Rhys/data/rs-1-0 --bind_ip localhost --oplogSize 128
mongod --replSet rs1 --port 27018 --dbpath=/users/Rhys/data/rs-1-1 --bind_ip localhost --oplogSize 128
mongod --replSet rs1 --port 27019 --dbpath=/users/Rhys/data/rs-1-2 --bind_ip localhost --oplogSize 128

2. Set up the local replica set and give tags to different nodes.
mongo localhost:27017

rsconf = {
  _id: 'rs1',
  members: [
    {
     _id: 0,
     host: 'localhost:27017',
     tags: { region: 'east', usage: 'production' }
    },
    {
     _id: 1,
     host: 'localhost:27018',
     tags: { region: 'east', usage: 'reporting' }
    },
    {
     _id: 2,
     host: 'localhost:27019',
     tags: { region: 'tagTester', usage: 'analytics' }
    }
   ]
}
rs.initiate(rsconf);

3. Connect with a url that has readPreferenceTags:

Basic 1 tag:
mongo mongodb://localhost:27017,localhost:27018,localhost:27019/?readPreference=secondary&readPreferenceTags=region:tagTester

Basic 2 tags:
mongodb://localhost:27017,localhost:27018,localhost:27019/?readPreference=secondary&readPreferenceTags=region:tagTester,usage:analytics

Multiple tag groups, we connect to the second one:
mongodb://localhost:27017,localhost:27018,localhost:27019/?readPreference=secondary&readPreferenceTags=region:nonExistant&readPreferenceTags=region:tagTester
```

I think this is a patch update. We'll need to bump version and pull into compass.

I also think this is probably a fix we might catch with typescript 🙊
