### PR TITLE
fix: safe async parsing of connection strings

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1060,7 +1060,7 @@ async function createConnectionFromUrl(url) {
 
   const isSrvRecord = url.startsWith('mongodb+srv://');
 
-  let attrs = Object.assign(
+  const attrs = Object.assign(
     {},
     {
       hosts: parsed.hosts,

--- a/lib/model.js
+++ b/lib/model.js
@@ -1149,9 +1149,13 @@ async function createConnectionFromUrl(url) {
 Connection.from = (url, callback) => {
   try {
     createConnectionFromUrl(url)
-      .then((connection) => callback(null, connection))
+      .then(
+        // setImmediate here prevents the callback to be executed again in the catch
+        // in case of errors.
+        (connection) => setImmediate(() => callback(null, connection))
+      )
       .catch(
-        // setImmediate will execute the callback in a different asynchronous context
+        // setImmediate executes the callback in a different asynchronous context
         // from the promise rejection. In this way if the callback throws
         // it would result in an unhandled exception rather that an unhandled
         // promise rejection which wouldn't be expected with a callback.

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,8 +1,9 @@
 /* eslint complexity: 0 */
 const URL = require('url');
 const toURL = URL.format;
-const { format } = require('util');
+const { format, promisify } = require('util');
 const fs = require('fs');
+
 const {
   assign,
   defaults,
@@ -1050,6 +1051,88 @@ Connection = AmpersandModel.extend({
   }
 });
 
+const parseConnectionStringAsPromise = promisify(parseConnectionString);
+
+async function createConnectionFromUrl(url) {
+  const unescapedUrl = unescape(url);
+
+  const parsed = await parseConnectionStringAsPromise(unescapedUrl);
+
+  const isSrvRecord = url.startsWith('mongodb+srv://');
+
+  let attrs = Object.assign(
+    {},
+    {
+      hosts: parsed.hosts,
+      hostname: isSrvRecord ? parsed.srvHost : parsed.hosts[0].host,
+      auth: parsed.auth,
+      isSrvRecord
+    },
+    parsed.options
+  );
+
+  if (!isSrvRecord) {
+    attrs.port = parsed.hosts[0].port;
+  }
+
+  // We don't inherit the drivers default values
+  // into our model's default values so only set `ns`
+  // if it was actually in the URL and not a default.
+  if (url.indexOf(parsed.defaultDatabase) > -1) {
+    attrs.ns = parsed.defaultDatabase;
+  }
+
+  // The `authStrategy` value for humans
+  let authStrategy = null;
+
+  if (attrs.authMechanism) {
+    authStrategy = attrs.authMechanism;
+  } else if (attrs.auth && attrs.auth.username && attrs.auth.password) {
+    authStrategy = 'DEFAULT';
+  } else if (attrs.auth && attrs.auth.username) {
+    authStrategy = 'MONGODB-X509';
+  }
+
+  attrs.authStrategy = authStrategy
+    ? AUTH_MECHANISM_TO_AUTH_STRATEGY[authStrategy]
+    : AUTH_STRATEGY_DEFAULT;
+
+  if (parsed.auth) {
+    let user = parsed.auth.username;
+    let password = parsed.auth.password;
+
+    user = decodeURIComponent(user);
+    password = decodeURIComponent(password);
+
+    if (attrs.authStrategy === 'LDAP') {
+      attrs.ldapUsername = user;
+      attrs.ldapPassword = password;
+    } else if (attrs.authStrategy === 'X509') {
+      attrs.x509Username = user;
+    } else if (attrs.authStrategy === 'KERBEROS') {
+      attrs.kerberosPrincipal = user;
+      attrs.kerberosPassword = password;
+    } else if (attrs.authStrategy === 'MONGODB') {
+      attrs.mongodbUsername = user;
+      attrs.mongodbPassword = password;
+
+      // authSource takes precedence, but fall back to admin
+      // @note Durran: This is not the documented behaviour of the connection string
+      // but the shell also does not fall back to the dbName and will use admin.
+      attrs.mongodbDatabaseName = decodeURIComponent(
+        attrs.authSource || Connection.MONGODB_DATABASE_NAME_DEFAULT
+      );
+
+      Object.assign(
+        attrs,
+        Connection._improveAtlasDefaults(url, attrs.auth.password, attrs.ns)
+      );
+    }
+  }
+
+  return new Connection(attrs);
+}
+
 /**
  * For easy command line integration.
  *
@@ -1064,116 +1147,20 @@ Connection = AmpersandModel.extend({
  * @param {Function} [callback]
  */
 Connection.from = (url, callback) => {
-  const MONGO = 'mongodb://';
-  const MONGO_SRV = 'mongodb+srv://';
-  let isSrvRecord = false;
-
-  /* eslint camelcase:0 */
-  if (!url) {
-    url = 'mongodb://localhost:27017';
+  try {
+    createConnectionFromUrl(url)
+      .then((connection) => callback(null, connection))
+      .catch(
+        // setImmediate will execute the callback in a different asynchronous context
+        // from the promise rejection. In this way if the callback throws
+        // it would result in an unhandled exception rather that an unhandled
+        // promise rejection which wouldn't be expected with a callback.
+        (error) => setImmediate(() => callback(error))
+      );
+  } catch (error) {
+    callback(error);
+    return;
   }
-
-  if (url.indexOf(MONGO) === -1 && url.indexOf(MONGO_SRV) === -1) {
-    url = `${MONGO}${url}`;
-  }
-
-  if (url.indexOf(MONGO_SRV) > -1) {
-    isSrvRecord = true;
-  }
-
-  const unescapedUrl = unescape(url);
-
-  parseConnectionString(unescapedUrl, (parseError, parsed) => {
-    if (parseError) {
-      return callback(parseError);
-    }
-
-    let attrs = Object.assign(
-      {},
-      {
-        hosts: parsed.hosts,
-        hostname: isSrvRecord ? parsed.srvHost : parsed.hosts[0].host,
-        auth: parsed.auth,
-        isSrvRecord
-      },
-      parsed.options
-    );
-
-    if (!isSrvRecord) {
-      attrs.port = parsed.hosts[0].port;
-    }
-
-    // We don't inherit the drivers default values
-    // into our model's default values so only set `ns`
-    // if it was actually in the URL and not a default.
-    if (url.indexOf(parsed.defaultDatabase) > -1) {
-      attrs.ns = parsed.defaultDatabase;
-    }
-
-    // The `authStrategy` value for humans
-    let authStrategy = null;
-
-    if (attrs.authMechanism) {
-      authStrategy = attrs.authMechanism;
-    } else if (attrs.auth && attrs.auth.username && attrs.auth.password) {
-      authStrategy = 'DEFAULT';
-    } else if (attrs.auth && attrs.auth.username) {
-      authStrategy = 'MONGODB-X509';
-    }
-
-    attrs.authStrategy = authStrategy
-      ? AUTH_MECHANISM_TO_AUTH_STRATEGY[authStrategy]
-      : AUTH_STRATEGY_DEFAULT;
-
-    if (parsed.auth) {
-      let user = parsed.auth.username;
-      let password = parsed.auth.password;
-
-      try {
-        user = decodeURIComponent(user);
-        password = decodeURIComponent(password);
-      } catch (decodeError) {
-        return callback(decodeError);
-      }
-
-      if (attrs.authStrategy === 'LDAP') {
-        attrs.ldapUsername = user;
-        attrs.ldapPassword = password;
-      } else if (attrs.authStrategy === 'X509') {
-        attrs.x509Username = user;
-      } else if (attrs.authStrategy === 'KERBEROS') {
-        attrs.kerberosPrincipal = user;
-        attrs.kerberosPassword = password;
-      } else if (attrs.authStrategy === 'MONGODB') {
-        attrs.mongodbUsername = user;
-        attrs.mongodbPassword = password;
-
-        // authSource takes precedence, but fall back to admin
-        // @note Durran: This is not the documented behaviour of the connection string
-        // but the shell also does not fall back to the dbName and will use admin.
-        try {
-          attrs.mongodbDatabaseName = decodeURIComponent(
-            attrs.authSource || Connection.MONGODB_DATABASE_NAME_DEFAULT,
-            callback
-          );
-        } catch (decodeError) {
-          return callback(decodeError);
-        }
-
-        Object.assign(
-          attrs,
-          Connection._improveAtlasDefaults(url, attrs.auth.password, attrs.ns)
-        );
-      }
-    }
-
-    try {
-      const connection = new Connection(attrs);
-      return callback(null, connection);
-    } catch (error) {
-      return callback(error);
-    }
-  });
 };
 
 /**

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,7 +1,7 @@
 /* eslint complexity: 0 */
 const URL = require('url');
 const toURL = URL.format;
-const { format, promisify } = require('util');
+const { format, promisify, callbackify } = require('util');
 const fs = require('fs');
 
 const {
@@ -1146,26 +1146,7 @@ async function createConnectionFromUrl(url) {
  * @param {String} [url]
  * @param {Function} [callback]
  */
-Connection.from = (url, callback) => {
-  try {
-    createConnectionFromUrl(url)
-      .then(
-        // setImmediate here prevents the callback to be executed again in the catch
-        // in case of errors.
-        (connection) => setImmediate(() => callback(null, connection))
-      )
-      .catch(
-        // setImmediate executes the callback in a different asynchronous context
-        // from the promise rejection. In this way if the callback throws
-        // it would result in an unhandled exception rather that an unhandled
-        // promise rejection which wouldn't be expected with a callback.
-        (error) => setImmediate(() => callback(error))
-      );
-  } catch (error) {
-    callback(error);
-    return;
-  }
-};
+Connection.from = callbackify(createConnectionFromUrl);
 
 /**
  * Helper function to improve the Atlas user experience by

--- a/test/parse-uri-common-targets.test.js
+++ b/test/parse-uri-common-targets.test.js
@@ -159,15 +159,6 @@ describe('connection model parser should parse URI strings for common connection
       );
     });
 
-    it('when prefix is not specified', (done) => {
-      Connection.from('localhost:27017', (error, result) => {
-        expect(error).to.not.exist;
-        expect(result.hostname).to.be.equal('localhost');
-        expect(result.port).to.be.equal(27017);
-        done();
-      });
-    });
-
     it('with explicit authSource', (done) => {
       Connection.from(
         'mongodb://%40rlo:w%40of@localhost:27017/dogdb?authMechanism=SCRAM-SHA-1&authSource=catdb',

--- a/test/parse-uri-common-targets.test.js
+++ b/test/parse-uri-common-targets.test.js
@@ -227,8 +227,8 @@ describe('connection model parser should parse URI strings for common connection
     it('when using X509 auth', (done) => {
       Connection.from(
         'mongodb://CN%253Dclient%252COU%253Darlo%252CO%253DMongoDB%252CL%253DPhiladelphia' +
-          '%252CST%253DPennsylvania%252CC%253DUS@localhost:27017/' +
-          'x509?authMechanism=MONGODB-X509',
+        '%252CST%253DPennsylvania%252CC%253DUS@localhost:27017/' +
+        'x509?authMechanism=MONGODB-X509',
         (error, result) => {
           expect(error).to.not.exist;
           expect(result.hostname).to.be.equal('localhost');
@@ -246,7 +246,7 @@ describe('connection model parser should parse URI strings for common connection
     it('when using KERBEROS auth', (done) => {
       Connection.from(
         'mongodb://arlo%252Fdog%2540krb5.mongodb.parts:w%40%40f@localhost:27017/' +
-          'kerberos?gssapiServiceName=mongodb&authMechanism=GSSAPI',
+        'kerberos?gssapiServiceName=mongodb&authMechanism=GSSAPI',
         (error, result) => {
           expect(error).to.not.exist;
           expect(result.hostname).to.be.equal('localhost');


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

Internal use of `async/await` and promises in `Connection.from` to simplify the code and properly deal with the asynchronous parsing in case of errors. 

NOTE: we are also dropping the "normalisation" of the scheme (adding the scheme if not present). Since the url scheme is validated in `compass-connect` that feature is never used, also not behaving properly:

```
http://my-host --> mongodb://http://my-host
```
```
bad-protocol://somehost?#mongodb+srv:// --> bad-protocol://somehost?#mongodb+srv://
```

To be precise this should probably be a new major version.


### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [x] Major (fix or feature that would cause existing functionality to change)
