### PR TITLE
fix(VSCODE-202): Allow x509 username to be optional in connection string parsing and building

### DIFF
--- a/test/build-uri.test.js
+++ b/test/build-uri.test.js
@@ -509,6 +509,23 @@ describe('Connection model builder', () => {
         done();
       });
     });
+
+    it('should not include credentials when using X509 auth and there is no username', (done) => {
+      const c = new Connection({
+        authStrategy: 'X509'
+      });
+
+      expect(c.driverAuthMechanism).to.be.equal('MONGODB-X509');
+      expect(c.driverUrl).to.be.equal(
+        'mongodb://localhost:27017/?authMechanism=MONGODB-X509' +
+          '&readPreference=primary&ssl=false&authSource=$external'
+      );
+
+      Connection.from(c.driverUrl, (error) => {
+        expect(error).to.not.exist;
+        done();
+      });
+    });
   });
 
   context('when building a connection object', () => {

--- a/test/parse-uri-common-targets.test.js
+++ b/test/parse-uri-common-targets.test.js
@@ -215,7 +215,7 @@ describe('connection model parser should parse URI strings for common connection
       );
     });
 
-    it('when using X509 auth', (done) => {
+    it('when using X509 auth with a username', (done) => {
       Connection.from(
         'mongodb://CN%253Dclient%252COU%253Darlo%252CO%253DMongoDB%252CL%253DPhiladelphia' +
         '%252CST%253DPennsylvania%252CC%253DUS@localhost:27017/' +
@@ -228,6 +228,21 @@ describe('connection model parser should parse URI strings for common connection
           expect(result.x509Username).to.be.equal(
             'CN=client,OU=arlo,O=MongoDB,L=Philadelphia,ST=Pennsylvania,C=US'
           );
+          expect(result.ns).to.be.equal('x509');
+          done();
+        }
+      );
+    });
+
+    it('when using X509 auth without a username', (done) => {
+      Connection.from(
+        'mongodb://localhost:27017/x509?authMechanism=MONGODB-X509',
+        (error, result) => {
+          expect(error).to.not.exist;
+          expect(result.hostname).to.be.equal('localhost');
+          expect(result.port).to.be.equal(27017);
+          expect(result.authStrategy).to.be.equal('X509');
+          expect(result.x509Username).to.be.equal(undefined);
           expect(result.ns).to.be.equal('x509');
           done();
         }


### PR DESCRIPTION
This updates our connection model to not require an auth username when the `authMechanism` is set to `MONGODB-X509` and we are building a connection string, or parsing a connection string.

This PR also updates parsing a URL to remove the clause where we would assume the auth mechanism is `MONGODB-X509` when just auth username was set.

This fixes an issue where we build an incorrect connection string in vscode, where x509 username is optional.