### PR TITLE
fix: Ensure error thrown on connect is forwarded COMPASS-4473

### DIFF
--- a/lib/ssh-tunnel.js
+++ b/lib/ssh-tunnel.js
@@ -50,8 +50,16 @@ SSHTunnel.prototype.createTunnel = function (done) {
       debug('ssh tunnel is ready.');
       this.tunnel.removeListener('error', onStartupError);
       done();
-    })
-    .connect(this.options);
+    });
+
+  process.nextTick(() => {
+    try {
+      this.tunnel.connect(this.options);
+    } catch (err) {
+      debug('ssh tunnel error during connect call');
+      onStartupError(err);
+    }
+  });
 
   return this.tunnel;
 };


### PR DESCRIPTION
## Description
When a keyfile with passphrase was selected for SSH Tunnel authentication and the passphrase is empty/invalid _no error message was displayed_ previously. The error is now caught and properly forwarded.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
