### PR TITLE
fix: don't require username with x509 auth

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -941,9 +941,9 @@ Connection = AmpersandModel.extend({
   },
   validateX509(attrs) {
     if (attrs.authStrategy === 'X509') {
-      if (!attrs.x509Username) {
+      if (attrs.sslMethod !== 'ALL') {
         throw new TypeError(
-          'The x509Username field is required when using X509 for authStrategy.'
+          'SSL method is required to be set to \'Server and Client\' when using x509 authentication'
         );
       }
     }

--- a/lib/model.js
+++ b/lib/model.js
@@ -868,15 +868,15 @@ Connection = AmpersandModel.extend({
       throw new TypeError('sslCA is required when ssl is SERVER.');
     } else if (attrs.sslMethod === 'ALL') {
       if (!attrs.sslCA) {
-        throw new TypeError('sslCA is required when ssl is ALL.');
-      }
-
-      if (!attrs.sslKey) {
-        throw new TypeError('sslKey is required when ssl is ALL.');
+        throw new TypeError('SSL \'Certificate Authority\' is required when the SSL method is set to \'Server and Client Validation\'.');
       }
 
       if (!attrs.sslCert) {
-        throw new TypeError('sslCert is required when ssl is ALL.');
+        throw new TypeError('SSL \'Client Certificate\' is required when the SSL method is set to \'Server and Client Validation\'.');
+      }
+
+      if (!attrs.sslKey) {
+        throw new TypeError('SSL \'Client Private Key\' is required when the SSL method is set to \'Server and Client Validation\'.');
       }
     }
   },
@@ -887,15 +887,15 @@ Connection = AmpersandModel.extend({
     ) {
       if (!attrs.mongodbUsername) {
         throw new TypeError(
-          'The mongodbUsername field is required when ' +
-            'using MONGODB or SCRAM-SHA-256 for authStrategy.'
+          'The \'Username\' field is required when ' +
+            'using \'Username/Password\' or \'SCRAM-SHA-256\' for authentication.'
         );
       }
 
       if (!attrs.mongodbPassword) {
         throw new TypeError(
-          'The mongodbPassword field is required when ' +
-            'using MONGODB or SCRAM-SHA-256 for authStrategy.'
+          'The \'Password\' field is required when ' +
+            'using \'Username/Password\' or \'SCRAM-SHA-256\' for authentication.'
         );
       }
     }
@@ -909,8 +909,8 @@ Connection = AmpersandModel.extend({
       if (attrs.kerberosServiceName) {
         throw new TypeError(
           format(
-            'The kerberosServiceName field does not apply when ' +
-              'using %s for authStrategy.',
+            'The Kerberos \'Service Name\' field does not apply when ' +
+              'using %s for authentication.',
             attrs.authStrategy
           )
         );
@@ -918,8 +918,8 @@ Connection = AmpersandModel.extend({
       if (attrs.kerberosPrincipal) {
         throw new TypeError(
           format(
-            'The kerberosPrincipal field does not apply when ' +
-              'using %s for authStrategy.',
+            'The Kerberos \'Principal\' field does not apply when ' +
+              'using %s for authentication.',
             attrs.authStrategy
           )
         );
@@ -927,15 +927,15 @@ Connection = AmpersandModel.extend({
       if (attrs.kerberosPassword) {
         throw new TypeError(
           format(
-            'The kerberosPassword field does not apply when ' +
-              'using %s for authStrategy.',
+            'The Kerberos \'Password\' field does not apply when ' +
+              'using %s for authentication.',
             attrs.authStrategy
           )
         );
       }
     } else if (!attrs.kerberosPrincipal) {
       throw new TypeError(
-        'The kerberosPrincipal field is required when using KERBEROS for authStrategy.'
+        'The Kerberos \'Principal\' field is required when using \'Kerberos\' for authentication.'
       );
     }
   },
@@ -943,7 +943,7 @@ Connection = AmpersandModel.extend({
     if (attrs.authStrategy === 'X509') {
       if (attrs.sslMethod !== 'ALL') {
         throw new TypeError(
-          'SSL method is required to be set to \'Server and Client\' when using x509 authentication'
+          'SSL method is required to be set to \'Server and Client Validation\' when using X.509 authentication.'
         );
       }
     }
@@ -953,16 +953,16 @@ Connection = AmpersandModel.extend({
       if (!attrs.ldapUsername) {
         throw new TypeError(
           format(
-            'The ldapUsername field is required when ' +
-              'using LDAP for authStrategy.'
+            'The \'Username\' field is required when ' +
+              'using \'LDAP\' for authentication.'
           )
         );
       }
       if (!attrs.ldapPassword) {
         throw new TypeError(
           format(
-            'The ldapPassword field is required when ' +
-              'using LDAP for authStrategy.'
+            'The \'Password\' field is required when ' +
+              'using LDAP for authentication.'
           )
         );
       }
@@ -978,7 +978,7 @@ Connection = AmpersandModel.extend({
 
       if (!attrs.sshTunnelPassword) {
         throw new TypeError(
-          'sslTunnelPassword is required when sshTunnel is USER_PASSWORD.'
+          '\'SSH Password\' is required when SSH Tunnel is set to \'Use Password\'.'
         );
       }
     } else if (attrs.sshTunnel === 'IDENTITY_FILE') {
@@ -986,7 +986,7 @@ Connection = AmpersandModel.extend({
 
       if (!attrs.sshTunnelIdentityFile) {
         throw new TypeError(
-          'sslTunnelIdentityFile is required when sshTunnel is IDENTITY_FILE.'
+          '\'SSH Identity File\' is required when SSH Tunnel is set to \'Use Identity File\'.'
         );
       }
     }
@@ -994,19 +994,19 @@ Connection = AmpersandModel.extend({
   validateStandardSshTunnelOptions(attrs) {
     if (!attrs.sshTunnelUsername) {
       throw new TypeError(
-        'sslTunnelUsername is required when sshTunnel is not NONE.'
+        '\'SSH Username\' is required when SSH Tunnel is set.'
       );
     }
 
     if (!attrs.sshTunnelHostname) {
       throw new TypeError(
-        'sslTunnelHostname is required when sshTunnel is not NONE.'
+        '\'SSH Hostname\' is required when SSH Tunnel is set.'
       );
     }
 
     if (!attrs.sshTunnelPort) {
       throw new TypeError(
-        'sslTunnelPort is required when sshTunnel is not NONE.'
+        '\'SSH Tunnel Port\' is required when SSH Tunnel is set.'
       );
     }
   },

--- a/test/build-uri.test.js
+++ b/test/build-uri.test.js
@@ -594,7 +594,7 @@ describe('Connection model builder', () => {
         const error = c.validate(attrs);
 
         expect(c.isValid()).to.be.equal(false);
-        expect(error.message).to.include('mongodbUsername field is required');
+        expect(error.message).to.include('The \'Username\' field is required when using \'Username/Password\' or \'SCRAM-SHA-256\' for authentication.');
       });
 
       it('should throw the error if auth is SCRAM-SHA-256 and mongodbPassword is missing', () => {
@@ -606,7 +606,7 @@ describe('Connection model builder', () => {
         const error = c.validate(attrs);
 
         expect(c.isValid()).to.be.equal(false);
-        expect(error.message).to.include('mongodbPassword field is required');
+        expect(error.message).to.equal('The \'Password\' field is required when using \'Username/Password\' or \'SCRAM-SHA-256\' for authentication.');
       });
 
       it('should throw the error if MONGODB auth receives non-applicable fields', () => {
@@ -619,8 +619,8 @@ describe('Connection model builder', () => {
         const error = c.validate(attrs);
 
         expect(c.isValid()).to.be.equal(false);
-        expect(error.message).to.include(
-          'kerberosServiceName field does not apply'
+        expect(error.message).to.equal(
+          'The Kerberos \'Service Name\' field does not apply when using MONGODB for authentication.'
         );
       });
 
@@ -683,7 +683,7 @@ describe('Connection model builder', () => {
         const error = c.validate(attrs);
 
         expect(c.isValid()).to.be.equal(false);
-        expect(error.message).to.include('mongodbUsername field is required');
+        expect(error.message).to.include('The \'Username\' field is required when using \'Username/Password\' or \'SCRAM-SHA-256\' for authentication.');
       });
 
       it('should throw the error if auth is MONGODB and mongodbPassword is missing', (done) => {
@@ -734,7 +734,7 @@ describe('Connection model builder', () => {
         const error = c.validate(attrs);
 
         expect(c.isValid()).to.be.equal(false);
-        expect(error.message).to.include('ldapUsername field is required');
+        expect(error.message).to.equal('The \'Username\' field is required when using \'LDAP\' for authentication.');
       });
 
       it('should throw the error if auth is LDAP and ldapPassword is missing', () => {
@@ -743,7 +743,7 @@ describe('Connection model builder', () => {
         const error = c.validate(attrs);
 
         expect(c.isValid()).to.be.equal(false);
-        expect(error.message).to.include('ldapPassword field is required');
+        expect(error.message).to.equal('The \'Password\' field is required when using LDAP for authentication.');
       });
 
       it('should set authStrategy to X509', (done) => {
@@ -781,7 +781,7 @@ describe('Connection model builder', () => {
         const error = c.validate(attrs);
 
         expect(c.isValid()).to.be.equal(false);
-        expect(error.message).to.include('SSL method is required to be set to \'Server and Client\' when using x509 authentication');
+        expect(error.message).to.equal('SSL method is required to be set to \'Server and Client Validation\' when using X.509 authentication.');
       });
 
       it('should set default mongodb gssapiServiceName when using KERBEROS auth', (done) => {
@@ -818,7 +818,7 @@ describe('Connection model builder', () => {
         const error = c.validate(attrs);
 
         expect(c.isValid()).to.be.equal(false);
-        expect(error.message).to.include('kerberosPrincipal field is required');
+        expect(error.message).to.equal('The Kerberos \'Principal\' field is required when using \'Kerberos\' for authentication.');
       });
 
       it('should *only* require a kerberosPrincipal', () => {
@@ -951,7 +951,7 @@ describe('Connection model builder', () => {
         const error = c.validate(attrs);
 
         expect(c.isValid()).to.be.equal(false);
-        expect(error.message).to.include('mongodbPassword field is required');
+        expect(error.message).to.equal('The \'Password\' field is required when using \'Username/Password\' or \'SCRAM-SHA-256\' for authentication.');
       });
 
       it('should generate the local port when using a ssh tunne and bind to local port does not exist', () => {

--- a/test/build-uri.test.js
+++ b/test/build-uri.test.js
@@ -760,13 +760,28 @@ describe('Connection model builder', () => {
         });
       });
 
-      it('should throw the error if auth is X509 and x509Username is missing', () => {
-        const attrs = { authStrategy: 'X509' };
+      it('should not throw the error if auth is X509 and x509Username is missing', () => {
+        const attrs = {
+          authStrategy: 'X509',
+          sslMethod: 'ALL',
+          sslCA: [fixture.ssl.ca],
+          sslCert: fixture.ssl.server,
+          sslKey: fixture.ssl.server
+        };
+        const c = new Connection(attrs);
+
+        expect(c.isValid()).to.be.equal(true);
+      });
+
+      it('should throw a validation error if auth is X509 and sslMethod is not "ALL"', () => {
+        const attrs = {
+          authStrategy: 'X509'
+        };
         const c = new Connection(attrs);
         const error = c.validate(attrs);
 
         expect(c.isValid()).to.be.equal(false);
-        expect(error.message).to.include('x509Username field is required');
+        expect(error.message).to.include('SSL method is required to be set to \'Server and Client\' when using x509 authentication');
       });
 
       it('should set default mongodb gssapiServiceName when using KERBEROS auth', (done) => {


### PR DESCRIPTION
We'll also want to update `compass-connect` so that the validation error when x509 is selected is shown properly. Right now it's not showing the actual validation errors, is just says `The required fields can not be empty` and highlights the x509 input.