### PR TITLE
feat(COMPASS-4517): Expose connection options

### DIFF
--- a/test/connect.test.js
+++ b/test/connect.test.js
@@ -20,6 +20,35 @@ describe('connection model connector', () => {
       require('mongodb-runner/mocha/after')({ port: 27018, version: '4.0.0' })
     );
 
+    it('should return connection config when connected successfully', (done) => {
+      Connection.from('mongodb://localhost:27018', (parseErr, model) => {
+        if (parseErr) throw parseErr;
+
+        connect(
+          model,
+          setupListeners,
+          (connectErr, client, { url, options }) => {
+            if (connectErr) throw connectErr;
+
+            assert.strictEqual(
+              url,
+              'mongodb://localhost:27018/?readPreference=primary&ssl=false'
+            );
+
+            assert.deepStrictEqual(options, {
+              connectWithNoPrimary: true,
+              readPreference: 'primary',
+              useNewUrlParser: true,
+              useUnifiedTopology: true
+            });
+
+            client.close(true);
+            done();
+          }
+        );
+      });
+    });
+
     it('should connect to `localhost:27018 with model`', (done) => {
       Connection.from('mongodb://localhost:27018', (parseErr, model) => {
         assert.equal(parseErr, null);


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description

This PR exposes connection options that are passed to the `MongoClient` to establish a connection in a connect done callback.

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context

Even though `driverOptions` and `driverUrl` are exposed on the connection model, they are not exactly the same options that are passed to the `MongoClient` when connecting to the server. To allow replication and reuse of the exact connections created by the connect.

In our particular case in scope of moving the mongo shell in compass in a separate thread we would need to replicate the connection in a thread with shell runtime and for this having an easy access to the exact options used by `MongoClient` will be very handy.

- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->
–

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->
–

## Types of changes

This is a minor change unless there are concerns about having a third argument in a done callback, which is not a very common pattern in node.

- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
