### PR TITLE
fix: when isSrvRecord is true do not default directConnection to true in driver connection options

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -218,6 +218,7 @@ const getTasks = (model, setupListeners) => {
       if (
         model.directConnection === undefined &&
         model.hosts.length === 1 &&
+        !model.isSrvRecord &&
         (model.replicaSet === undefined || model.replicaSet === '')
       ) {
         // Previous to the node driver 3.6.3, directConnection was


### PR DESCRIPTION
In the connection string we use the driver to resolve the replica set name, so the `directConnection` option was not being set there. However, in the connection form we do not resolve the replica set name before connecting, so it was blank and therefor we were setting directConnection to true when it was an srv record, since there's only one host and no replica set. This PR updates it so that we check if it's an srvRecord so we don't set `directConnection` true on those connection.