### PR TITLE
fix: bring back 'port' data type

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -1,0 +1,7 @@
+module.exports = {
+  port: {
+    set: (val) => {
+      return { type: 'port', val };
+    }
+  }
+};

--- a/lib/model.js
+++ b/lib/model.js
@@ -16,6 +16,7 @@ const AmpersandModel = require('ampersand-model');
 const AmpersandCollection = require('ampersand-rest-collection');
 const { ReadPreference } = require('mongodb');
 const { parseConnectionString } = require('mongodb/lib/core');
+const dataTypes = require('./data-types');
 const localPortGenerator = require('./local-port-generator');
 
 /**
@@ -80,7 +81,7 @@ assign(props, {
   ns: { type: 'string', default: undefined },
   isSrvRecord: { type: 'boolean', default: false },
   hostname: { type: 'string', default: 'localhost' },
-  port: { type: 'number', default: 27017 },
+  port: { type: 'port', default: 27017 },
   hosts: {
     type: 'array',
     default: () => [{ host: 'localhost', port: 27017 }]
@@ -370,11 +371,11 @@ assign(props, {
   /**
    * The SSH port of the remote host.
    */
-  sshTunnelPort: { type: 'number', default: 22 },
+  sshTunnelPort: { type: 'port', default: 22 },
   /**
    * Bind the localhost endpoint of the SSH Tunnel to this port.
    */
-  sshTunnelBindToLocalPort: { type: 'number', default: undefined },
+  sshTunnelBindToLocalPort: { type: 'port', default: undefined },
   /**
    * The optional SSH username for the remote host.
    */
@@ -769,6 +770,7 @@ Connection = AmpersandModel.extend({
   props,
   derived,
   session,
+  dataTypes,
   initialize(attrs) {
     if (attrs) {
       if (typeof attrs === 'string') {

--- a/test/ssh-tunnel.test.js
+++ b/test/ssh-tunnel.test.js
@@ -35,6 +35,14 @@ describe('sshTunnel', function () {
 
       assert.equal(c.sshTunnelPort, 22);
     });
+
+    it('should also accept a string', () => {
+      const c = new Connection({
+        sshTunnelPort: '2222'
+      });
+
+      assert.equal(c.sshTunnelPort, '2222');
+    });
   });
 
   describe('NONE', () => {


### PR DESCRIPTION
## Description
This brings back the `port` data type removed by #341. Pinning the port data type to `number` would cause Compass to fail loading stored favorites.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
