### PR TITLE
fix: incorrect connection title on form connections

### DIFF
--- a/lib/extended-model.js
+++ b/lib/extended-model.js
@@ -87,13 +87,13 @@ const ExtendedConnection = Connection.extend(storageMixin, {
           return this.hostname;
         }
 
-        if (this.hosts && this.hosts.length) {
+        if (this.hosts && this.hosts.length > 1) {
           return this.hosts.map(
             ({ host, port }) => `${host}:${port}`
           ).join(',');
         }
 
-        return this.hostname;
+        return `${this.hostname}:${this.port}`;
       }
     }
   },

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -22,8 +22,14 @@ describe('Connection', () => {
 
     it('returns hosts if the connection is not srv', () => {
       assert.strictEqual(
-        new Connection({ hosts: [{ host: 'example.com', port: 12345 }] }).title,
-        'example.com:12345'
+        new Connection({ hosts: [{
+          host: 'example.com',
+          port: 12345
+        }, {
+          host: 'example123.com',
+          port: 123452
+        }] }).title,
+        'example.com:12345,example123.com:123452'
       );
     });
 
@@ -37,15 +43,16 @@ describe('Connection', () => {
       );
     });
 
-    it('falls back to hostname if nothing else match', () => {
+    it('falls back to hostname:port if nothing else match', () => {
       assert.strictEqual(
         new Connection({
           isSrvRecord: false,
           isFavorite: false,
           hosts: [],
-          hostname: 'somehost'
+          hostname: 'somehost',
+          port: 12345
         }).title,
-        'somehost'
+        'somehost:12345'
       );
     });
   });


### PR DESCRIPTION
This PR updates so that the model has the correct title on connections created with the connection form (host and port aren't set).

before:

https://user-images.githubusercontent.com/1791149/107398392-dc4a6580-6aff-11eb-906b-701d5bb7d4d0.mp4



after:

https://user-images.githubusercontent.com/1791149/107397687-2d0d8e80-6aff-11eb-9685-f07bd96984b8.mp4

