### PR TITLE
fix: don't cache title and use port as title dep

### DIFF
--- a/lib/extended-model.js
+++ b/lib/extended-model.js
@@ -76,6 +76,7 @@ const ExtendedConnection = Connection.extend(storageMixin, {
         'isFavorite',
         'isSrvRecord',
         'hostname',
+        'port',
         'hosts'
       ],
       fn() {
@@ -94,7 +95,8 @@ const ExtendedConnection = Connection.extend(storageMixin, {
         }
 
         return `${this.hostname}:${this.port}`;
-      }
+      },
+      cache: false
     }
   },
   serialize() {


### PR DESCRIPTION
Fixes the title of connections so we don't cache them. This was causing the title not to change when a user updated the port.